### PR TITLE
Add label data assets and asset manager

### DIFF
--- a/MusicLabel.uproject
+++ b/MusicLabel.uproject
@@ -3,13 +3,23 @@
 	"EngineAssociation": "5.6",
 	"Category": "",
 	"Description": "",
-	"Modules": [
-		{
-			"Name": "MusicLabel",
-			"Type": "Runtime",
-			"LoadingPhase": "Default"
-		}
-	],
+        "Modules": [
+                {
+                        "Name": "MusicLabel",
+                        "Type": "Runtime",
+                        "LoadingPhase": "Default"
+                },
+                {
+                        "Name": "LabelManager",
+                        "Type": "Runtime",
+                        "LoadingPhase": "Default"
+                },
+                {
+                        "Name": "LabelManagerEditor",
+                        "Type": "Editor",
+                        "LoadingPhase": "Default"
+                }
+        ],
 	"Plugins": [
 		{
 			"Name": "ModelingToolsEditorMode",

--- a/Source/LabelManager/LabelManager.Build.cs
+++ b/Source/LabelManager/LabelManager.Build.cs
@@ -1,0 +1,12 @@
+using UnrealBuildTool;
+
+public class LabelManager : ModuleRules
+{
+    public LabelManager(ReadOnlyTargetRules Target) : base(Target)
+    {
+        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
+
+        PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine" });
+        PrivateDependencyModuleNames.AddRange(new string[] { });
+    }
+}

--- a/Source/LabelManager/Private/LabelAssetManager.cpp
+++ b/Source/LabelManager/Private/LabelAssetManager.cpp
@@ -1,0 +1,21 @@
+#include "CoreMinimal.h"
+#include "LabelAssetManager.h"
+#include "Engine/Engine.h"
+
+const FPrimaryAssetType ULabelAssetManager::SongAssetType(TEXT("Song"));
+const FPrimaryAssetType ULabelAssetManager::ArtistAssetType(TEXT("Artist"));
+const FPrimaryAssetType ULabelAssetManager::DecadeAssetType(TEXT("Decade"));
+const FPrimaryAssetType ULabelAssetManager::GenreAssetType(TEXT("Genre"));
+const FPrimaryAssetType ULabelAssetManager::RegionMarketAssetType(TEXT("RegionMarket"));
+const FPrimaryAssetType ULabelAssetManager::VenueAssetType(TEXT("Venue"));
+
+ULabelAssetManager& ULabelAssetManager::Get()
+{
+    ULabelAssetManager* Singleton = Cast<ULabelAssetManager>(GEngine->AssetManager);
+    return *Singleton;
+}
+
+void ULabelAssetManager::StartInitialLoading()
+{
+    Super::StartInitialLoading();
+}

--- a/Source/LabelManager/Private/LabelDataAssets.cpp
+++ b/Source/LabelManager/Private/LabelDataAssets.cpp
@@ -1,0 +1,38 @@
+#include "CoreMinimal.h"
+#include "LabelDataAssets.h"
+#include "LabelAssetManager.h"
+
+FPrimaryAssetId USongAsset::GetPrimaryAssetId() const
+{
+    return FPrimaryAssetId(ULabelAssetManager::SongAssetType, GetFName());
+}
+
+FPrimaryAssetId UArtistAsset::GetPrimaryAssetId() const
+{
+    return FPrimaryAssetId(ULabelAssetManager::ArtistAssetType, GetFName());
+}
+
+FPrimaryAssetId UDecadeAsset::GetPrimaryAssetId() const
+{
+    return FPrimaryAssetId(ULabelAssetManager::DecadeAssetType, GetFName());
+}
+
+FPrimaryAssetId UGenreAsset::GetPrimaryAssetId() const
+{
+    return FPrimaryAssetId(ULabelAssetManager::GenreAssetType, GetFName());
+}
+
+FPrimaryAssetId URegionMarketAsset::GetPrimaryAssetId() const
+{
+    return FPrimaryAssetId(ULabelAssetManager::RegionMarketAssetType, GetFName());
+}
+
+FPrimaryAssetId UVenueAsset::GetPrimaryAssetId() const
+{
+    return FPrimaryAssetId(ULabelAssetManager::VenueAssetType, GetFName());
+}
+
+FPrimaryAssetId UEconomyConfigAsset::GetPrimaryAssetId() const
+{
+    return FPrimaryAssetId(FPrimaryAssetType(TEXT("EconomyConfig")), GetFName());
+}

--- a/Source/LabelManager/Private/LabelManagerModule.cpp
+++ b/Source/LabelManager/Private/LabelManagerModule.cpp
@@ -1,0 +1,3 @@
+#include "Modules/ModuleManager.h"
+
+IMPLEMENT_MODULE(FDefaultModuleImpl, LabelManager);

--- a/Source/LabelManager/Public/LabelAssetManager.h
+++ b/Source/LabelManager/Public/LabelAssetManager.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "Engine/AssetManager.h"
+#include "LabelAssetManager.generated.h"
+
+/**
+ * Central asset manager for label assets.
+ */
+UCLASS()
+class LABELMANAGER_API ULabelAssetManager : public UAssetManager
+{
+    GENERATED_BODY()
+public:
+    /** Returns the global asset manager instance */
+    static ULabelAssetManager& Get();
+
+    static const FPrimaryAssetType SongAssetType;
+    static const FPrimaryAssetType ArtistAssetType;
+    static const FPrimaryAssetType DecadeAssetType;
+    static const FPrimaryAssetType GenreAssetType;
+    static const FPrimaryAssetType RegionMarketAssetType;
+    static const FPrimaryAssetType VenueAssetType;
+
+protected:
+    // UAssetManager interface
+    virtual void StartInitialLoading() override;
+};

--- a/Source/LabelManager/Public/LabelDataAssets.h
+++ b/Source/LabelManager/Public/LabelDataAssets.h
@@ -1,0 +1,297 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Engine/PrimaryDataAsset.h"
+#include "LabelDataAssets.generated.h"
+
+class UCurveFloat;
+class USoundWave;
+class UGenreAsset;
+class UObject;
+
+/** Rights type for song licensing */
+UENUM(BlueprintType)
+enum class ERightsType : uint8
+{
+    Owned UMETA(DisplayName="Owned"),
+    Licensed UMETA(DisplayName="Licensed")
+};
+
+/** Artist entity type */
+UENUM(BlueprintType)
+enum class EArtistType : uint8
+{
+    Solo UMETA(DisplayName="Solo"),
+    Band UMETA(DisplayName="Band")
+};
+
+/** Personality flag markers */
+UENUM(BlueprintType)
+enum class EPersonalityFlag : uint8
+{
+    Ego UMETA(DisplayName="Ego"),
+    Activism UMETA(DisplayName="Activism"),
+    RiskTaker UMETA(DisplayName="RiskTaker")
+};
+
+/** Trait values for an artist */
+USTRUCT(BlueprintType)
+struct FArtistAttributes
+{
+    GENERATED_BODY()
+private:
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Attributes", meta=(AllowPrivateAccess="true"))
+    float Talent = 0.f;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Attributes", meta=(AllowPrivateAccess="true"))
+    float Charisma = 0.f;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Attributes", meta=(AllowPrivateAccess="true"))
+    float Reliability = 0.f;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Attributes", meta=(AllowPrivateAccess="true"))
+    float MarketAppeal = 0.f;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Attributes", meta=(AllowPrivateAccess="true"))
+    float Stamina = 0.f;
+public:
+    UFUNCTION(BlueprintPure, Category="Attributes") float GetTalent() const { return Talent; }
+    UFUNCTION(BlueprintPure, Category="Attributes") float GetCharisma() const { return Charisma; }
+    UFUNCTION(BlueprintPure, Category="Attributes") float GetReliability() const { return Reliability; }
+    UFUNCTION(BlueprintPure, Category="Attributes") float GetMarketAppeal() const { return MarketAppeal; }
+    UFUNCTION(BlueprintPure, Category="Attributes") float GetStamina() const { return Stamina; }
+};
+
+/** Contractual terms with an artist */
+USTRUCT(BlueprintType)
+struct FContractTerms
+{
+    GENERATED_BODY()
+private:
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Contract", meta=(AllowPrivateAccess="true"))
+    int32 Advance = 0;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Contract", meta=(AllowPrivateAccess="true"))
+    float RoyaltySplit = 0.f;
+public:
+    UFUNCTION(BlueprintPure, Category="Contract") int32 GetAdvance() const { return Advance; }
+    UFUNCTION(BlueprintPure, Category="Contract") float GetRoyaltySplit() const { return RoyaltySplit; }
+};
+
+/** Song data asset */
+UCLASS(BlueprintType)
+class LABELMANAGER_API USongAsset : public UPrimaryDataAsset
+{
+    GENERATED_BODY()
+public:
+    UFUNCTION(BlueprintPure, Category="Song") const FString& GetSongId() const { return SongId; }
+    UFUNCTION(BlueprintPure, Category="Song") const FString& GetTitle() const { return Title; }
+    UFUNCTION(BlueprintPure, Category="Song") const TSoftObjectPtr<UGenreAsset>& GetGenre() const { return Genre; }
+    UFUNCTION(BlueprintPure, Category="Song") const TSoftObjectPtr<UGenreAsset>& GetSubgenre() const { return Subgenre; }
+    UFUNCTION(BlueprintPure, Category="Song") const TArray<FString>& GetTags() const { return Tags; }
+    UFUNCTION(BlueprintPure, Category="Song") float GetQualityBase() const { return QualityBase; }
+    UFUNCTION(BlueprintPure, Category="Song") int32 GetLengthSec() const { return LengthSec; }
+    UFUNCTION(BlueprintPure, Category="Song") int32 GetTempoBPM() const { return TempoBPM; }
+    UFUNCTION(BlueprintPure, Category="Song") UCurveFloat* GetEnergyCurve() const { return EnergyCurve; }
+    UFUNCTION(BlueprintPure, Category="Song") USoundWave* GetAudioRef() const { return AudioRef; }
+    UFUNCTION(BlueprintPure, Category="Song") float GetPreviewStartSec() const { return PreviewStartSec; }
+    UFUNCTION(BlueprintPure, Category="Song") ERightsType GetRights() const { return Rights; }
+    UFUNCTION(BlueprintPure, Category="Song") int32 GetCostToUse() const { return CostToUse; }
+    UFUNCTION(BlueprintPure, Category="Song") float GetRoyaltyRate() const { return RoyaltyRate; }
+
+    virtual FPrimaryAssetId GetPrimaryAssetId() const override;
+
+private:
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Song", meta=(AllowPrivateAccess="true"))
+    FString SongId;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Song", meta=(AllowPrivateAccess="true"))
+    FString Title;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Song", meta=(AllowPrivateAccess="true"))
+    TSoftObjectPtr<UGenreAsset> Genre;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Song", meta=(AllowPrivateAccess="true"))
+    TSoftObjectPtr<UGenreAsset> Subgenre;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Song", meta=(AllowPrivateAccess="true"))
+    TArray<FString> Tags;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Song", meta=(AllowPrivateAccess="true"))
+    float QualityBase = 0.f;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Song", meta=(AllowPrivateAccess="true"))
+    int32 LengthSec = 0;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Song", meta=(AllowPrivateAccess="true"))
+    int32 TempoBPM = 0;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Song", meta=(AllowPrivateAccess="true"))
+    UCurveFloat* EnergyCurve = nullptr;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Song", meta=(AllowPrivateAccess="true"))
+    USoundWave* AudioRef = nullptr;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Song", meta=(AllowPrivateAccess="true"))
+    float PreviewStartSec = 0.f;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Song", meta=(AllowPrivateAccess="true"))
+    ERightsType Rights = ERightsType::Owned;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Song", meta=(AllowPrivateAccess="true"))
+    int32 CostToUse = 0;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Song", meta=(AllowPrivateAccess="true"))
+    float RoyaltyRate = 0.f;
+};
+
+/** Artist data asset */
+UCLASS(BlueprintType)
+class LABELMANAGER_API UArtistAsset : public UPrimaryDataAsset
+{
+    GENERATED_BODY()
+public:
+    UFUNCTION(BlueprintPure, Category="Artist") const FString& GetName() const { return Name; }
+    UFUNCTION(BlueprintPure, Category="Artist") EArtistType GetType() const { return Type; }
+    UFUNCTION(BlueprintPure, Category="Artist") const FArtistAttributes& GetAttributes() const { return Attributes; }
+    UFUNCTION(BlueprintPure, Category="Artist") const TArray<TSoftObjectPtr<UGenreAsset>>& GetGenreAffinity() const { return GenreAffinity; }
+    UFUNCTION(BlueprintPure, Category="Artist") const TArray<EPersonalityFlag>& GetPersonalityFlags() const { return PersonalityFlags; }
+    UFUNCTION(BlueprintPure, Category="Artist") const TSoftObjectPtr<UObject>& GetMetaHumanProfileRef() const { return MetaHumanProfileRef; }
+    UFUNCTION(BlueprintPure, Category="Artist") const FContractTerms& GetContractTerms() const { return ContractTerms; }
+
+    virtual FPrimaryAssetId GetPrimaryAssetId() const override;
+
+private:
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Artist", meta=(AllowPrivateAccess="true"))
+    FString Name;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Artist", meta=(AllowPrivateAccess="true"))
+    EArtistType Type = EArtistType::Solo;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Artist", meta=(AllowPrivateAccess="true"))
+    FArtistAttributes Attributes;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Artist", meta=(AllowPrivateAccess="true"))
+    TArray<TSoftObjectPtr<UGenreAsset>> GenreAffinity;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Artist", meta=(AllowPrivateAccess="true"))
+    TArray<EPersonalityFlag> PersonalityFlags;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Artist", meta=(AllowPrivateAccess="true"))
+    TSoftObjectPtr<UObject> MetaHumanProfileRef;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Artist", meta=(AllowPrivateAccess="true"))
+    FContractTerms ContractTerms;
+};
+
+/** Decade data asset */
+UCLASS(BlueprintType)
+class LABELMANAGER_API UDecadeAsset : public UPrimaryDataAsset
+{
+    GENERATED_BODY()
+public:
+    UFUNCTION(BlueprintPure, Category="Decade") int32 GetStartYear() const { return StartYear; }
+    UFUNCTION(BlueprintPure, Category="Decade") int32 GetEndYear() const { return EndYear; }
+    UFUNCTION(BlueprintPure, Category="Decade") const TArray<FString>& GetTechUnlocks() const { return TechUnlocks; }
+    UFUNCTION(BlueprintPure, Category="Decade") const TArray<FString>& GetMarketingChannels() const { return MarketingChannels; }
+    UFUNCTION(BlueprintPure, Category="Decade") const TMap<FString,float>& GetEventWeights() const { return EventWeights; }
+
+    virtual FPrimaryAssetId GetPrimaryAssetId() const override;
+
+private:
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Decade", meta=(AllowPrivateAccess="true"))
+    int32 StartYear = 0;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Decade", meta=(AllowPrivateAccess="true"))
+    int32 EndYear = 0;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Decade", meta=(AllowPrivateAccess="true"))
+    TArray<FString> TechUnlocks;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Decade", meta=(AllowPrivateAccess="true"))
+    TArray<FString> MarketingChannels;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Decade", meta=(AllowPrivateAccess="true"))
+    TMap<FString, float> EventWeights;
+};
+
+/** Genre data asset */
+UCLASS(BlueprintType)
+class LABELMANAGER_API UGenreAsset : public UPrimaryDataAsset
+{
+    GENERATED_BODY()
+public:
+    UFUNCTION(BlueprintPure, Category="Genre") const FString& GetName() const { return Name; }
+    UFUNCTION(BlueprintPure, Category="Genre") UCurveFloat* GetPopularityCurveByDecade() const { return PopularityCurveByDecade; }
+    UFUNCTION(BlueprintPure, Category="Genre") const TArray<FString>& GetDemographicAffinity() const { return DemographicAffinity; }
+    UFUNCTION(BlueprintPure, Category="Genre") const TArray<FString>& GetTechFit() const { return TechFit; }
+    UFUNCTION(BlueprintPure, Category="Genre") float GetCrossOverPotential() const { return CrossOverPotential; }
+
+    virtual FPrimaryAssetId GetPrimaryAssetId() const override;
+
+private:
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Genre", meta=(AllowPrivateAccess="true"))
+    FString Name;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Genre", meta=(AllowPrivateAccess="true"))
+    UCurveFloat* PopularityCurveByDecade = nullptr;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Genre", meta=(AllowPrivateAccess="true"))
+    TArray<FString> DemographicAffinity;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Genre", meta=(AllowPrivateAccess="true"))
+    TArray<FString> TechFit;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Genre", meta=(AllowPrivateAccess="true"))
+    float CrossOverPotential = 0.f;
+};
+
+/** Region market data asset */
+UCLASS(BlueprintType)
+class LABELMANAGER_API URegionMarketAsset : public UPrimaryDataAsset
+{
+    GENERATED_BODY()
+public:
+    UFUNCTION(BlueprintPure, Category="Region") const FString& GetName() const { return Name; }
+    UFUNCTION(BlueprintPure, Category="Region") int32 GetPopulation() const { return Population; }
+    UFUNCTION(BlueprintPure, Category="Region") float GetIncomeIndex() const { return IncomeIndex; }
+    UFUNCTION(BlueprintPure, Category="Region") const TMap<FString,float>& GetTasteWeightsPerGenre() const { return TasteWeightsPerGenre; }
+    UFUNCTION(BlueprintPure, Category="Region") const TMap<FString,float>& GetChannelReachMultipliers() const { return ChannelReachMultipliers; }
+
+    virtual FPrimaryAssetId GetPrimaryAssetId() const override;
+
+private:
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Region", meta=(AllowPrivateAccess="true"))
+    FString Name;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Region", meta=(AllowPrivateAccess="true"))
+    int32 Population = 0;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Region", meta=(AllowPrivateAccess="true"))
+    float IncomeIndex = 0.f;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Region", meta=(AllowPrivateAccess="true"))
+    TMap<FString, float> TasteWeightsPerGenre;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Region", meta=(AllowPrivateAccess="true"))
+    TMap<FString, float> ChannelReachMultipliers;
+};
+
+/** Venue data asset */
+UCLASS(BlueprintType)
+class LABELMANAGER_API UVenueAsset : public UPrimaryDataAsset
+{
+    GENERATED_BODY()
+public:
+    UFUNCTION(BlueprintPure, Category="Venue") const FString& GetName() const { return Name; }
+    UFUNCTION(BlueprintPure, Category="Venue") int32 GetCapacity() const { return Capacity; }
+    UFUNCTION(BlueprintPure, Category="Venue") float GetCostProfile() const { return CostProfile; }
+    UFUNCTION(BlueprintPure, Category="Venue") float GetAcoustics() const { return Acoustics; }
+    UFUNCTION(BlueprintPure, Category="Venue") const FString& GetCity() const { return City; }
+    UFUNCTION(BlueprintPure, Category="Venue") float GetPrestige() const { return Prestige; }
+
+    virtual FPrimaryAssetId GetPrimaryAssetId() const override;
+
+private:
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Venue", meta=(AllowPrivateAccess="true"))
+    FString Name;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Venue", meta=(AllowPrivateAccess="true"))
+    int32 Capacity = 0;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Venue", meta=(AllowPrivateAccess="true"))
+    float CostProfile = 0.f;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Venue", meta=(AllowPrivateAccess="true"))
+    float Acoustics = 0.f;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Venue", meta=(AllowPrivateAccess="true"))
+    FString City;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Venue", meta=(AllowPrivateAccess="true"))
+    float Prestige = 0.f;
+};
+
+/** Economy configuration data */
+UCLASS(BlueprintType)
+class LABELMANAGER_API UEconomyConfigAsset : public UPrimaryDataAsset
+{
+    GENERATED_BODY()
+public:
+    UFUNCTION(BlueprintPure, Category="Economy") float GetStudioHourlyRate() const { return StudioHourlyRate; }
+    UFUNCTION(BlueprintPure, Category="Economy") const TMap<FString,float>& GetDistributionFees() const { return DistributionFees; }
+    UFUNCTION(BlueprintPure, Category="Economy") float GetMarketingCPM() const { return MarketingCPM; }
+    UFUNCTION(BlueprintPure, Category="Economy") UCurveFloat* GetSeasonalEffects() const { return SeasonalEffects; }
+
+    virtual FPrimaryAssetId GetPrimaryAssetId() const override;
+
+private:
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Economy", meta=(AllowPrivateAccess="true"))
+    float StudioHourlyRate = 0.f;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Economy", meta=(AllowPrivateAccess="true"))
+    TMap<FString, float> DistributionFees;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Economy", meta=(AllowPrivateAccess="true"))
+    float MarketingCPM = 0.f;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Economy", meta=(AllowPrivateAccess="true"))
+    UCurveFloat* SeasonalEffects = nullptr;
+};
+

--- a/Source/LabelManagerEditor/LabelManagerEditor.Build.cs
+++ b/Source/LabelManagerEditor/LabelManagerEditor.Build.cs
@@ -1,0 +1,11 @@
+using UnrealBuildTool;
+
+public class LabelManagerEditor : ModuleRules
+{
+    public LabelManagerEditor(ReadOnlyTargetRules Target) : base(Target)
+    {
+        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
+        PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "UnrealEd", "LabelManager" });
+        PrivateDependencyModuleNames.AddRange(new string[] { });
+    }
+}

--- a/Source/LabelManagerEditor/Private/LabelManagerEditorModule.cpp
+++ b/Source/LabelManagerEditor/Private/LabelManagerEditorModule.cpp
@@ -1,0 +1,3 @@
+#include "Modules/ModuleManager.h"
+
+IMPLEMENT_MODULE(FDefaultModuleImpl, LabelManagerEditor);


### PR DESCRIPTION
## Summary
- add primary data assets for songs, artists, decades, genres, markets, venues and economy config
- implement central asset manager exposing primary asset types
- register new modules for runtime and editor

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68adcc39efbc832eaabdabc057203c1d