### PR TITLE
Add subsystem skeletons

### DIFF
--- a/Source/MusicLabel/MusicLabel.Build.cs
+++ b/Source/MusicLabel/MusicLabel.Build.cs
@@ -8,7 +8,7 @@ public class MusicLabel : ModuleRules
 	{
 		PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
 	
-		PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "EnhancedInput" });
+                PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "EnhancedInput", "LabelManager" });
 
 		PrivateDependencyModuleNames.AddRange(new string[] {  });
 

--- a/Source/MusicLabel/Subsystems/ContentCatalogSubsystem.cpp
+++ b/Source/MusicLabel/Subsystems/ContentCatalogSubsystem.cpp
@@ -1,0 +1,18 @@
+#include "ContentCatalogSubsystem.h"
+#include "LabelManager/Public/LabelDataAssets.h"
+
+TArray<USongAsset*> UContentCatalogSubsystem::FindSongsByGenre(FName Genre) const
+{
+    return {};
+}
+
+UArtistAsset* UContentCatalogSubsystem::GetArtistByName(FName ArtistName) const
+{
+    return nullptr;
+}
+
+TArray<FString> UContentCatalogSubsystem::GetGenreTrends() const
+{
+    return {};
+}
+

--- a/Source/MusicLabel/Subsystems/ContentCatalogSubsystem.h
+++ b/Source/MusicLabel/Subsystems/ContentCatalogSubsystem.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Subsystems/GameInstanceSubsystem.h"
+#include "ContentCatalogSubsystem.generated.h"
+
+class USongAsset;
+class UArtistAsset;
+class UGenreAsset;
+
+/** Provides catalog access to songs, artists, and genres. */
+UCLASS()
+class MUSICLABEL_API UContentCatalogSubsystem : public UGameInstanceSubsystem
+{
+    GENERATED_BODY()
+public:
+    /** Retrieve songs matching a specific genre. */
+    UFUNCTION(BlueprintCallable, Category="ContentCatalog")
+    TArray<USongAsset*> FindSongsByGenre(FName Genre) const;
+
+    /** Get an artist asset by name. */
+    UFUNCTION(BlueprintCallable, Category="ContentCatalog")
+    UArtistAsset* GetArtistByName(FName ArtistName) const;
+
+    /** Gather trends across genres. */
+    UFUNCTION(BlueprintCallable, Category="ContentCatalog")
+    TArray<FString> GetGenreTrends() const;
+
+private:
+    /** Map of song assets by identifier. */
+    TMap<FName, USongAsset*> SongAssets;
+
+    /** Map of artist assets by name. */
+    TMap<FName, UArtistAsset*> ArtistAssets;
+
+    /** Map of genre assets by name. */
+    TMap<FName, UGenreAsset*> GenreAssets;
+};
+

--- a/Source/MusicLabel/Subsystems/EconomySubsystem.cpp
+++ b/Source/MusicLabel/Subsystems/EconomySubsystem.cpp
@@ -1,0 +1,15 @@
+#include "EconomySubsystem.h"
+
+void UEconomySubsystem::ApplyTransaction(const FTransaction& Transaction)
+{
+}
+
+float UEconomySubsystem::CalculateWeeklyCashflow() const
+{
+    return 0.0f;
+}
+
+void UEconomySubsystem::ReportPAndL() const
+{
+}
+

--- a/Source/MusicLabel/Subsystems/EconomySubsystem.h
+++ b/Source/MusicLabel/Subsystems/EconomySubsystem.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Subsystems/GameInstanceSubsystem.h"
+#include "EconomySubsystem.generated.h"
+
+struct FTransaction;
+
+/** Handles financial calculations and tracking. */
+UCLASS()
+class MUSICLABEL_API UEconomySubsystem : public UGameInstanceSubsystem
+{
+    GENERATED_BODY()
+public:
+    /** Apply a financial transaction. */
+    UFUNCTION(BlueprintCallable, Category="Economy")
+    void ApplyTransaction(const FTransaction& Transaction);
+
+    /** Calculate cash flow for the current week. */
+    UFUNCTION(BlueprintCallable, Category="Economy")
+    float CalculateWeeklyCashflow() const;
+
+    /** Report profit and loss figures. */
+    UFUNCTION(BlueprintCallable, Category="Economy")
+    void ReportPAndL() const;
+
+private:
+    /** Current cash balance. */
+    float CashBalance = 0.0f;
+
+    /** Revenue transactions. */
+    TArray<FTransaction> RevenueStreams;
+
+    /** Expense transactions. */
+    TArray<FTransaction> Expenses;
+};
+

--- a/Source/MusicLabel/Subsystems/EventSubsystem.cpp
+++ b/Source/MusicLabel/Subsystems/EventSubsystem.cpp
@@ -1,0 +1,14 @@
+#include "EventSubsystem.h"
+
+void UEventSubsystem::TriggerEvent(const FGameEvent& Event)
+{
+}
+
+void UEventSubsystem::ResolveEvent()
+{
+}
+
+void UEventSubsystem::ScheduleEvent(const FGameEvent& Event)
+{
+}
+

--- a/Source/MusicLabel/Subsystems/EventSubsystem.h
+++ b/Source/MusicLabel/Subsystems/EventSubsystem.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Subsystems/GameInstanceSubsystem.h"
+#include "EventSubsystem.generated.h"
+
+struct FGameEvent;
+
+/** Manages random or triggered game events. */
+UCLASS()
+class MUSICLABEL_API UEventSubsystem : public UGameInstanceSubsystem
+{
+    GENERATED_BODY()
+public:
+    /** Trigger an immediate event. */
+    UFUNCTION(BlueprintCallable, Category="Events")
+    void TriggerEvent(const FGameEvent& Event);
+
+    /** Resolve the next event in the queue. */
+    UFUNCTION(BlueprintCallable, Category="Events")
+    void ResolveEvent();
+
+    /** Schedule a future event. */
+    UFUNCTION(BlueprintCallable, Category="Events")
+    void ScheduleEvent(const FGameEvent& Event);
+
+private:
+    /** Queue of pending events. */
+    TArray<FGameEvent> EventQueue;
+};
+

--- a/Source/MusicLabel/Subsystems/LabelSimSubsystem.cpp
+++ b/Source/MusicLabel/Subsystems/LabelSimSubsystem.cpp
@@ -1,0 +1,18 @@
+#include "LabelSimSubsystem.h"
+
+void ULabelSimSubsystem::TickDay()
+{
+}
+
+void ULabelSimSubsystem::UpdateCharts()
+{
+}
+
+void ULabelSimSubsystem::ProcessEvents()
+{
+}
+
+void ULabelSimSubsystem::ApplyDecadeModifiers()
+{
+}
+

--- a/Source/MusicLabel/Subsystems/LabelSimSubsystem.h
+++ b/Source/MusicLabel/Subsystems/LabelSimSubsystem.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Subsystems/GameInstanceSubsystem.h"
+#include "LabelSimSubsystem.generated.h"
+
+class UArtistAsset;
+struct FRelease;
+
+/** Subsystem managing label simulation timeline and events. */
+UCLASS()
+class MUSICLABEL_API ULabelSimSubsystem : public UGameInstanceSubsystem
+{
+    GENERATED_BODY()
+public:
+    /** Advance simulation by one day. */
+    UFUNCTION(BlueprintCallable, Category="LabelSim")
+    void TickDay();
+
+    /** Update music charts for the current day. */
+    UFUNCTION(BlueprintCallable, Category="LabelSim")
+    void UpdateCharts();
+
+    /** Process daily events. */
+    UFUNCTION(BlueprintCallable, Category="LabelSim")
+    void ProcessEvents();
+
+    /** Apply modifiers based on the current decade. */
+    UFUNCTION(BlueprintCallable, Category="LabelSim")
+    void ApplyDecadeModifiers();
+
+private:
+    /** Current date of the simulation. */
+    FDateTime CurrentDate;
+
+    /** Releases active on the charts. */
+    TArray<FRelease> ActiveReleases;
+
+    /** Artists currently signed to the label. */
+    TArray<UArtistAsset*> SignedArtists;
+};
+

--- a/Source/MusicLabel/Subsystems/PerformanceSubsystem.cpp
+++ b/Source/MusicLabel/Subsystems/PerformanceSubsystem.cpp
@@ -1,0 +1,14 @@
+#include "PerformanceSubsystem.h"
+
+void UPerformanceSubsystem::StartPerformance(UArtistAsset* Artist, USongAsset* Song)
+{
+}
+
+void UPerformanceSubsystem::StopPerformance()
+{
+}
+
+void UPerformanceSubsystem::SpawnCrowd()
+{
+}
+

--- a/Source/MusicLabel/Subsystems/PerformanceSubsystem.h
+++ b/Source/MusicLabel/Subsystems/PerformanceSubsystem.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Subsystems/GameInstanceSubsystem.h"
+#include "PerformanceSubsystem.generated.h"
+
+class UArtistAsset;
+class USongAsset;
+class ULevelStreaming;
+class UObject;
+
+/** Handles real-time performance simulation. */
+UCLASS()
+class MUSICLABEL_API UPerformanceSubsystem : public UGameInstanceSubsystem
+{
+    GENERATED_BODY()
+public:
+    /** Start a performance for the given artist and song. */
+    UFUNCTION(BlueprintCallable, Category="Performance")
+    void StartPerformance(UArtistAsset* Artist, USongAsset* Song);
+
+    /** Stop the current performance. */
+    UFUNCTION(BlueprintCallable, Category="Performance")
+    void StopPerformance();
+
+    /** Spawn audience crowd actors. */
+    UFUNCTION(BlueprintCallable, Category="Performance")
+    void SpawnCrowd();
+
+private:
+    /** Streaming level representing the show. */
+    ULevelStreaming* CurrentShow = nullptr;
+
+    /** Controller for managing crowd behavior. */
+    UObject* CrowdController = nullptr;
+};
+

--- a/Source/MusicLabel/Subsystems/PersistenceSubsystem.cpp
+++ b/Source/MusicLabel/Subsystems/PersistenceSubsystem.cpp
@@ -1,0 +1,14 @@
+#include "PersistenceSubsystem.h"
+
+void UPersistenceSubsystem::SaveGameState()
+{
+}
+
+void UPersistenceSubsystem::LoadGameState()
+{
+}
+
+void UPersistenceSubsystem::MigrateSaveVersion(int32 FromVersion)
+{
+}
+

--- a/Source/MusicLabel/Subsystems/PersistenceSubsystem.h
+++ b/Source/MusicLabel/Subsystems/PersistenceSubsystem.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Subsystems/GameInstanceSubsystem.h"
+#include "PersistenceSubsystem.generated.h"
+
+/** Handles saving and loading of game state. */
+UCLASS()
+class MUSICLABEL_API UPersistenceSubsystem : public UGameInstanceSubsystem
+{
+    GENERATED_BODY()
+public:
+    /** Save current game state. */
+    UFUNCTION(BlueprintCallable, Category="Persistence")
+    void SaveGameState();
+
+    /** Load previously saved game state. */
+    UFUNCTION(BlueprintCallable, Category="Persistence")
+    void LoadGameState();
+
+    /** Migrate save files to a new version. */
+    UFUNCTION(BlueprintCallable, Category="Persistence")
+    void MigrateSaveVersion(int32 FromVersion);
+};
+

--- a/Source/MusicLabel/Subsystems/ProgressionSubsystem.cpp
+++ b/Source/MusicLabel/Subsystems/ProgressionSubsystem.cpp
@@ -1,0 +1,14 @@
+#include "ProgressionSubsystem.h"
+
+void UProgressionSubsystem::AdvanceDecade()
+{
+}
+
+void UProgressionSubsystem::UnlockTech(FName TechId)
+{
+}
+
+void UProgressionSubsystem::ApplyEraShifts()
+{
+}
+

--- a/Source/MusicLabel/Subsystems/ProgressionSubsystem.h
+++ b/Source/MusicLabel/Subsystems/ProgressionSubsystem.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Subsystems/GameInstanceSubsystem.h"
+#include "ProgressionSubsystem.generated.h"
+
+class UDecadeAsset;
+
+/** Tracks player progression through decades and technology. */
+UCLASS()
+class MUSICLABEL_API UProgressionSubsystem : public UGameInstanceSubsystem
+{
+    GENERATED_BODY()
+public:
+    /** Advance to the next decade. */
+    UFUNCTION(BlueprintCallable, Category="Progression")
+    void AdvanceDecade();
+
+    /** Unlock a new technology. */
+    UFUNCTION(BlueprintCallable, Category="Progression")
+    void UnlockTech(FName TechId);
+
+    /** Apply era-specific shifts to the simulation. */
+    UFUNCTION(BlueprintCallable, Category="Progression")
+    void ApplyEraShifts();
+
+private:
+    /** Current active decade. */
+    UDecadeAsset* CurrentDecade = nullptr;
+
+    /** List of unlocked technology IDs. */
+    TArray<FName> UnlockedTech;
+};
+

--- a/Source/MusicLabel/Subsystems/TourSubsystem.cpp
+++ b/Source/MusicLabel/Subsystems/TourSubsystem.cpp
@@ -1,0 +1,14 @@
+#include "TourSubsystem.h"
+
+void UTourSubsystem::PlanTour(const FTour& NewTour)
+{
+}
+
+void UTourSubsystem::SimulateConcert()
+{
+}
+
+void UTourSubsystem::CalculateTourOutcome()
+{
+}
+

--- a/Source/MusicLabel/Subsystems/TourSubsystem.h
+++ b/Source/MusicLabel/Subsystems/TourSubsystem.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Subsystems/GameInstanceSubsystem.h"
+#include "TourSubsystem.generated.h"
+
+struct FTour;
+class UVenueAsset;
+
+/** Handles tour planning and simulation. */
+UCLASS()
+class MUSICLABEL_API UTourSubsystem : public UGameInstanceSubsystem
+{
+    GENERATED_BODY()
+public:
+    /** Plan a new tour. */
+    UFUNCTION(BlueprintCallable, Category="Tour")
+    void PlanTour(const FTour& NewTour);
+
+    /** Simulate a concert for the active tour. */
+    UFUNCTION(BlueprintCallable, Category="Tour")
+    void SimulateConcert();
+
+    /** Calculate outcomes for the ongoing tour. */
+    UFUNCTION(BlueprintCallable, Category="Tour")
+    void CalculateTourOutcome();
+
+private:
+    /** Tours currently in progress. */
+    TArray<FTour> ActiveTours;
+
+    /** Database of potential venues. */
+    TArray<UVenueAsset*> VenueDatabase;
+};
+


### PR DESCRIPTION
## Summary
- add label simulation, content catalog, economy, events, tour, performance, progression, and persistence subsystem skeletons
- hook LabelManager module so subsystems can use asset types

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68adcf2f0c68832eb5cfadd9588abefe