### PR TITLE
Define basic gameplay data structs

### DIFF
--- a/Source/MusicLabel/MusicLabelTypes.h
+++ b/Source/MusicLabel/MusicLabelTypes.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "MusicLabelTypes.generated.h"
+
+/** Represents a financial transaction in the game's economy. */
+USTRUCT(BlueprintType)
+struct FTransaction
+{
+    GENERATED_BODY()
+
+    /** Description of the transaction. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Transaction")
+    FString Description;
+
+    /** Monetary value of the transaction. Positive for revenue, negative for expense. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Transaction")
+    float Amount = 0.0f;
+};
+
+/** Data describing an artist tour. */
+USTRUCT(BlueprintType)
+struct FTour
+{
+    GENERATED_BODY()
+
+    /** Name of the tour. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Tour")
+    FString Name;
+
+    /** Cities or venues to visit during the tour. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Tour")
+    TArray<FString> Stops;
+};
+
+/** Basic definition of a game event. */
+USTRUCT(BlueprintType)
+struct FGameEvent
+{
+    GENERATED_BODY()
+
+    /** Text describing the event. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Event")
+    FString Description;
+
+    /** Priority used to order events; higher values handled first. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Event")
+    int32 Priority = 0;
+};
+

--- a/Source/MusicLabel/Subsystems/EconomySubsystem.h
+++ b/Source/MusicLabel/Subsystems/EconomySubsystem.h
@@ -2,9 +2,8 @@
 
 #include "CoreMinimal.h"
 #include "Subsystems/GameInstanceSubsystem.h"
+#include "MusicLabelTypes.h"
 #include "EconomySubsystem.generated.h"
-
-struct FTransaction;
 
 /** Handles financial calculations and tracking. */
 UCLASS()

--- a/Source/MusicLabel/Subsystems/EventSubsystem.h
+++ b/Source/MusicLabel/Subsystems/EventSubsystem.h
@@ -2,9 +2,8 @@
 
 #include "CoreMinimal.h"
 #include "Subsystems/GameInstanceSubsystem.h"
+#include "MusicLabelTypes.h"
 #include "EventSubsystem.generated.h"
-
-struct FGameEvent;
 
 /** Manages random or triggered game events. */
 UCLASS()

--- a/Source/MusicLabel/Subsystems/TourSubsystem.h
+++ b/Source/MusicLabel/Subsystems/TourSubsystem.h
@@ -2,9 +2,9 @@
 
 #include "CoreMinimal.h"
 #include "Subsystems/GameInstanceSubsystem.h"
+#include "MusicLabelTypes.h"
 #include "TourSubsystem.generated.h"
 
-struct FTour;
 class UVenueAsset;
 
 /** Handles tour planning and simulation. */


### PR DESCRIPTION
## Summary
- add `MusicLabelTypes` header implementing `FTransaction`, `FTour`, and `FGameEvent`
- include shared structs in economy, tour, and event subsystems

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68add33b20f8832e8180e6b6a80ba3c6