### PR TITLE
Add workflow method stubs for simulation, releases, tours, and finance

### DIFF
--- a/Source/MusicLabel/Subsystems/EconomySubsystem.cpp
+++ b/Source/MusicLabel/Subsystems/EconomySubsystem.cpp
@@ -13,3 +13,23 @@ void UEconomySubsystem::ReportPAndL() const
 {
 }
 
+void UEconomySubsystem::TrackCosts()
+{
+    // TODO: Record studio expenses, marketing spend, and advance payments.
+}
+
+void UEconomySubsystem::CollectRevenues()
+{
+    // TODO: Collect income from sales, streaming, ticketing, merchandise, and licensing.
+}
+
+void UEconomySubsystem::GenerateMonthlyReport()
+{
+    // TODO: Aggregate transactions and output monthly P&L statements.
+}
+
+void UEconomySubsystem::RecoupAdvances()
+{
+    // TODO: Deduct advances before calculating artist royalties.
+}
+

--- a/Source/MusicLabel/Subsystems/EconomySubsystem.h
+++ b/Source/MusicLabel/Subsystems/EconomySubsystem.h
@@ -24,6 +24,22 @@ public:
     UFUNCTION(BlueprintCallable, Category="Economy")
     void ReportPAndL() const;
 
+    /** Track studio costs, marketing spend, and advances. */
+    UFUNCTION(BlueprintCallable, Category="Economy")
+    void TrackCosts();
+
+    /** Collect revenues from sales, streaming, tickets, merch, and licensing. */
+    UFUNCTION(BlueprintCallable, Category="Economy")
+    void CollectRevenues();
+
+    /** Generate monthly profit and loss reports. */
+    UFUNCTION(BlueprintCallable, Category="Economy")
+    void GenerateMonthlyReport();
+
+    /** Recoup advances before paying artist royalties. */
+    UFUNCTION(BlueprintCallable, Category="Economy")
+    void RecoupAdvances();
+
 private:
     /** Current cash balance. */
     float CashBalance = 0.0f;

--- a/Source/MusicLabel/Subsystems/LabelSimSubsystem.cpp
+++ b/Source/MusicLabel/Subsystems/LabelSimSubsystem.cpp
@@ -2,17 +2,68 @@
 
 void ULabelSimSubsystem::TickDay()
 {
+    // 1. Apply decade modifiers (tech, marketing reach, piracy risk).
+    ApplyDecadeModifiers();
+
+    // 2. Process queued events (scandals, awards, trends).
+    ProcessEvents();
+
+    // 3. Update marketing exposures for all active releases.
+    UpdateMarketingExposures();
+
+    // 4. Calculate consumer demand (demographic × region × genre).
+    CalculateDemand();
+
+    // 5. Convert demand into sales/streams for active releases.
+    ConvertDemandToSales();
+
+    // 6. Update charts weekly.
+    UpdateCharts();
+
+    // 7. Update artist state (fame, morale, fatigue).
+    UpdateArtistStates();
+
+    // 8. Apply finance transactions (revenue, costs, royalties).
+    ApplyFinanceTransactions();
 }
 
 void ULabelSimSubsystem::UpdateCharts()
 {
+    // TODO: Recalculate chart positions based on current sales and streams.
 }
 
 void ULabelSimSubsystem::ProcessEvents()
 {
+    // TODO: Resolve queued events such as scandals, awards, and trends.
 }
 
 void ULabelSimSubsystem::ApplyDecadeModifiers()
 {
+    // TODO: Adjust simulation parameters according to current decade.
+}
+
+void ULabelSimSubsystem::UpdateMarketingExposures()
+{
+    // TODO: Update marketing reach for each active release.
+}
+
+void ULabelSimSubsystem::CalculateDemand()
+{
+    // TODO: Calculate demand considering demographics, regions, and genres.
+}
+
+void ULabelSimSubsystem::ConvertDemandToSales()
+{
+    // TODO: Convert demand metrics into sales and streaming numbers.
+}
+
+void ULabelSimSubsystem::UpdateArtistStates()
+{
+    // TODO: Update fame, morale, and fatigue for signed artists.
+}
+
+void ULabelSimSubsystem::ApplyFinanceTransactions()
+{
+    // TODO: Apply daily financial transactions like revenue, costs, and royalties.
 }
 

--- a/Source/MusicLabel/Subsystems/LabelSimSubsystem.h
+++ b/Source/MusicLabel/Subsystems/LabelSimSubsystem.h
@@ -29,6 +29,26 @@ public:
     UFUNCTION(BlueprintCallable, Category="LabelSim")
     void ApplyDecadeModifiers();
 
+    /** Update marketing exposure values for active releases. */
+    UFUNCTION(BlueprintCallable, Category="LabelSim")
+    void UpdateMarketingExposures();
+
+    /** Calculate consumer demand across demographics and regions. */
+    UFUNCTION(BlueprintCallable, Category="LabelSim")
+    void CalculateDemand();
+
+    /** Convert demand into sales and streaming numbers. */
+    UFUNCTION(BlueprintCallable, Category="LabelSim")
+    void ConvertDemandToSales();
+
+    /** Update fame, morale, and fatigue for all artists. */
+    UFUNCTION(BlueprintCallable, Category="LabelSim")
+    void UpdateArtistStates();
+
+    /** Apply daily revenue, costs, and royalty transactions. */
+    UFUNCTION(BlueprintCallable, Category="LabelSim")
+    void ApplyFinanceTransactions();
+
 private:
     /** Current date of the simulation. */
     FDateTime CurrentDate;

--- a/Source/MusicLabel/Subsystems/ReleaseSubsystem.cpp
+++ b/Source/MusicLabel/Subsystems/ReleaseSubsystem.cpp
@@ -1,0 +1,30 @@
+#include "ReleaseSubsystem.h"
+
+void UReleaseSubsystem::SelectArtist(UArtistAsset* Artist)
+{
+    // TODO: Set the artist who will be featured in the release.
+}
+
+void UReleaseSubsystem::ChooseSongs(const TArray<FSong>& Songs)
+{
+    // TODO: Store selected songs for the release.
+}
+
+void UReleaseSubsystem::BookStudio()
+{
+    // TODO: Reserve studio time and resources.
+}
+
+void UReleaseSubsystem::RecordSongs()
+{
+    // TODO: Record the chosen songs during the booked sessions.
+}
+
+void UReleaseSubsystem::ReleaseMusic()
+{
+    // TODO: Determine release type (Single, EP, Album).
+    // TODO: Select distribution options (Vinyl, Cassette, CD, Digital, Streaming).
+    // TODO: Plan marketing (Radio, TV, MTV, Social Media, Influencers).
+    // TODO: Calculate chart position from sales, marketing reach, and critic reviews.
+}
+

--- a/Source/MusicLabel/Subsystems/ReleaseSubsystem.h
+++ b/Source/MusicLabel/Subsystems/ReleaseSubsystem.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Subsystems/GameInstanceSubsystem.h"
+#include "ReleaseSubsystem.generated.h"
+
+class UArtistAsset;
+struct FSong;
+
+/** Handles planning and execution of music releases. */
+UCLASS()
+class MUSICLABEL_API UReleaseSubsystem : public UGameInstanceSubsystem
+{
+    GENERATED_BODY()
+public:
+    /** Select an artist for the upcoming release. */
+    UFUNCTION(BlueprintCallable, Category="Release")
+    void SelectArtist(UArtistAsset* Artist);
+
+    /** Choose songs to include in the release. */
+    UFUNCTION(BlueprintCallable, Category="Release")
+    void ChooseSongs(const TArray<FSong>& Songs);
+
+    /** Book studio time for recording. */
+    UFUNCTION(BlueprintCallable, Category="Release")
+    void BookStudio();
+
+    /** Record the selected songs. */
+    UFUNCTION(BlueprintCallable, Category="Release")
+    void RecordSongs();
+
+    /** Publish the release with distribution and marketing plans. */
+    UFUNCTION(BlueprintCallable, Category="Release")
+    void ReleaseMusic();
+};
+

--- a/Source/MusicLabel/Subsystems/TourSubsystem.cpp
+++ b/Source/MusicLabel/Subsystems/TourSubsystem.cpp
@@ -2,13 +2,22 @@
 
 void UTourSubsystem::PlanTour(const FTour& NewTour)
 {
+    // TODO: Select artist for the tour.
+    // TODO: Plan route across target regions.
+    // TODO: Book venues for each stop.
+    // TODO: Budget travel and production costs.
 }
 
 void UTourSubsystem::SimulateConcert()
 {
+    // TODO: Simulate ticket and merchandise sales.
+    // TODO: Apply fame gains from the performance.
+    // TODO: Optionally launch PerformanceSubsystem for 3D concert playback.
 }
 
 void UTourSubsystem::CalculateTourOutcome()
 {
+    // TODO: Apply fatigue to the performing artist.
+    // TODO: Calculate risks such as injuries or scandals.
 }
 


### PR DESCRIPTION
## Summary
- Document daily simulation loop steps in `LabelSimSubsystem::TickDay`
- Introduce `ReleaseSubsystem` with stubs for selecting artists, songs, recording, and releasing
- Expand tour and economy subsystems with detailed workflow stubs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68add3545ebc832e981d5e93dc09c213