### PR TITLE
Add FSong struct

### DIFF
--- a/Source/MusicLabel/MusicLabelTypes.h
+++ b/Source/MusicLabel/MusicLabelTypes.h
@@ -48,3 +48,22 @@ struct FGameEvent
     int32 Priority = 0;
 };
 
+/** Represents a single piece of music. */
+USTRUCT(BlueprintType)
+struct FSong
+{
+    GENERATED_BODY()
+
+    /** Title of the song. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Song")
+    FString Title;
+
+    /** Length of the song in seconds. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Song")
+    int32 LengthSec = 0;
+
+    /** Tempo of the song in beats per minute. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Song")
+    int32 TempoBPM = 0;
+};
+

--- a/Source/MusicLabel/Subsystems/ReleaseSubsystem.h
+++ b/Source/MusicLabel/Subsystems/ReleaseSubsystem.h
@@ -2,10 +2,10 @@
 
 #include "CoreMinimal.h"
 #include "Subsystems/GameInstanceSubsystem.h"
+#include "MusicLabelTypes.h"
 #include "ReleaseSubsystem.generated.h"
 
 class UArtistAsset;
-struct FSong;
 
 /** Handles planning and execution of music releases. */
 UCLASS()


### PR DESCRIPTION
## Summary
- define `FSong` data structure for representing song metadata
- include `MusicLabelTypes` in `UReleaseSubsystem` for song selection

## Testing
- `./Build.sh` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68add68ba344832eaacfa73119ff1d09