### PR TITLE
Add dashboard UI widgets, view model, and style

### DIFF
--- a/Config/DefaultGame.ini
+++ b/Config/DefaultGame.ini
@@ -4,3 +4,5 @@ CommonButtonAcceptKeyHandling=TriggerClick
 
 [/Script/EngineSettings.GeneralProjectSettings]
 ProjectID=7C05F83043709CF27DDC6EB6DBB0CB2D
+[/Script/Engine.Engine]
++ActiveGameplayModules=LabelManager

--- a/Source/LabelManager/LabelManager.Build.cs
+++ b/Source/LabelManager/LabelManager.Build.cs
@@ -6,7 +6,7 @@ public class LabelManager : ModuleRules
     {
         PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
 
-        PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine" });
+        PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "UMG", "Slate", "SlateCore" });
         PrivateDependencyModuleNames.AddRange(new string[] { });
     }
 }

--- a/Source/LabelManager/Private/LabelManagerModule.cpp
+++ b/Source/LabelManager/Private/LabelManagerModule.cpp
@@ -1,3 +1,17 @@
 #include "Modules/ModuleManager.h"
+#include "Style/LabelUIStyle.h"
 
-IMPLEMENT_MODULE(FDefaultModuleImpl, LabelManager);
+class FLabelManagerModule : public IModuleInterface
+{
+public:
+    virtual void StartupModule() override
+    {
+        FLabelUIStyle::Initialize();
+    }
+    virtual void ShutdownModule() override
+    {
+        FLabelUIStyle::Shutdown();
+    }
+};
+
+IMPLEMENT_MODULE(FLabelManagerModule, LabelManager);

--- a/Source/LabelManager/Private/Style/LabelUIStyle.cpp
+++ b/Source/LabelManager/Private/Style/LabelUIStyle.cpp
@@ -1,0 +1,57 @@
+#include "Style/LabelUIStyle.h"
+#include "Styling/SlateStyleRegistry.h"
+#include "Styling/CoreStyle.h"
+
+TSharedPtr<FLabelUIStyle> FLabelUIStyle::Instance = nullptr;
+
+FLabelUIStyle::FLabelUIStyle()
+    : FSlateStyleSet(GetStyleSetName())
+{
+    ColorBackground = FLinearColor(0.05f, 0.05f, 0.05f);
+    ColorPanel = FLinearColor(0.1f, 0.1f, 0.1f);
+    ColorAccent = FLinearColor(0.0f, 0.5f, 1.0f);
+    ColorTextDim = FLinearColor(0.6f, 0.6f, 0.6f);
+
+    Heading = FTextBlockStyle()
+        .SetFont(FCoreStyle::GetDefaultFontStyle("Bold", 24))
+        .SetColorAndOpacity(FSlateColor(FLinearColor::White));
+
+    TileNumber = FTextBlockStyle()
+        .SetFont(FCoreStyle::GetDefaultFontStyle("Bold", 32))
+        .SetColorAndOpacity(FSlateColor(ColorAccent));
+
+    Body = FTextBlockStyle()
+        .SetFont(FCoreStyle::GetDefaultFontStyle("Regular", 12))
+        .SetColorAndOpacity(FSlateColor(FLinearColor::White));
+
+    StandardPadding = FMargin(8.f);
+}
+
+void FLabelUIStyle::Initialize()
+{
+    if (!Instance.IsValid())
+    {
+        Instance = MakeShared<FLabelUIStyle>();
+        FSlateStyleRegistry::RegisterSlateStyle(*Instance);
+    }
+}
+
+void FLabelUIStyle::Shutdown()
+{
+    if (Instance.IsValid())
+    {
+        FSlateStyleRegistry::UnRegisterSlateStyle(*Instance);
+        Instance.Reset();
+    }
+}
+
+const ISlateStyle& FLabelUIStyle::Get()
+{
+    return *Instance;
+}
+
+FName FLabelUIStyle::GetStyleSetName()
+{
+    static FName StyleName(TEXT("LabelUIStyle"));
+    return StyleName;
+}

--- a/Source/LabelManager/Private/UI/DashboardViewModel.cpp
+++ b/Source/LabelManager/Private/UI/DashboardViewModel.cpp
@@ -1,0 +1,31 @@
+#include "UI/DashboardViewModel.h"
+
+UDashboardViewModel::UDashboardViewModel()
+{
+    RefreshAll();
+}
+
+void UDashboardViewModel::RefreshAll()
+{
+    Kpi.Cash = 125000.0;
+    Kpi.WeeklyStreams = 540000;
+    Kpi.ChartingTitles = 12;
+    Kpi.ActiveCampaigns = 3;
+
+    News.Reset();
+    News.Add({FText::FromString("Artist A tops charts"), FDateTime::UtcNow()});
+    News.Add({FText::FromString("Label signs new talent"), FDateTime::UtcNow().AddDays(-1)});
+
+    Releases.Reset();
+    Releases.Add({FText::FromString("Album X"), FText::FromString("LP"), FDateTime::UtcNow().AddDays(5)});
+    Releases.Add({FText::FromString("Single Y"), FText::FromString("Single"), FDateTime::UtcNow().AddDays(12)});
+
+    MarketStats.Reset();
+    MarketStats.Add({FName("NorthAmerica"), 0.8f});
+    MarketStats.Add({FName("Europe"), 0.6f});
+    MarketStats.Add({FName("Asia"), 0.4f});
+
+    Actions.Reset();
+    Actions.Add({FText::FromString("Review campaign budgets"), FName("BudgetReview")});
+    Actions.Add({FText::FromString("Schedule artist interviews"), FName("ScheduleInterviews")});
+}

--- a/Source/LabelManager/Private/UI/WidgetLibrary.cpp
+++ b/Source/LabelManager/Private/UI/WidgetLibrary.cpp
@@ -1,0 +1,23 @@
+#include "UI/WidgetLibrary.h"
+#include "UI/Widget_DashboardLayout.h"
+#include "UI/DashboardViewModel.h"
+#include "Blueprint/UserWidget.h"
+
+UWidget_DashboardLayout* UWidgetLibrary::CreateDashboard(UWorld* World, APlayerController* PC)
+{
+    if (!World || !PC)
+    {
+        return nullptr;
+    }
+
+    UDashboardViewModel* ViewModel = NewObject<UDashboardViewModel>(World);
+    ViewModel->RefreshAll();
+
+    UWidget_DashboardLayout* Layout = CreateWidget<UWidget_DashboardLayout>(PC, UWidget_DashboardLayout::StaticClass());
+    if (Layout)
+    {
+        Layout->SetViewModel(ViewModel);
+        Layout->AddToViewport();
+    }
+    return Layout;
+}

--- a/Source/LabelManager/Private/UI/Widget_ActionEntry.cpp
+++ b/Source/LabelManager/Private/UI/Widget_ActionEntry.cpp
@@ -1,0 +1,32 @@
+#include "UI/Widget_ActionEntry.h"
+#include "Components/TextBlock.h"
+#include "Components/Button.h"
+#include "TimerManager.h"
+
+void UWidget_ActionEntry::NativeOnListItemObjectSet(UObject* ListItem)
+{
+    USuggestedActionObject* Obj = Cast<USuggestedActionObject>(ListItem);
+    if (Obj && ActionLabelText)
+    {
+        ActionLabelText->SetText(Obj->Action.Label);
+        ActionLabelText->SetToolTipText(Obj->Action.Label);
+    }
+    PlayFadeIn();
+}
+
+void UWidget_ActionEntry::PlayFadeIn()
+{
+    SetRenderOpacity(0.f);
+    float Opacity = 0.f;
+    FTimerHandle Timer;
+    GetWorld()->GetTimerManager().SetTimer(Timer, [this, Opacity]() mutable
+    {
+        SetRenderOpacity(Opacity);
+        Opacity += 0.1f;
+        if (Opacity >= 1.f)
+        {
+            SetRenderOpacity(1.f);
+            GetWorld()->GetTimerManager().ClearTimer(Timer);
+        }
+    }, 0.05f, true);
+}

--- a/Source/LabelManager/Private/UI/Widget_DashboardLayout.cpp
+++ b/Source/LabelManager/Private/UI/Widget_DashboardLayout.cpp
@@ -1,0 +1,69 @@
+#include "UI/Widget_DashboardLayout.h"
+#include "UI/Widget_KpiTiles.h"
+#include "UI/Widget_NewsFeed.h"
+#include "UI/Widget_ReleaseCalendar.h"
+#include "UI/Widget_MarketHeatmap.h"
+#include "UI/Widget_SuggestedActions.h"
+#include "Components/CanvasPanel.h"
+#include "Components/GridPanel.h"
+#include "Components/SizeBox.h"
+#include "UI/DashboardViewModel.h"
+
+void UWidget_DashboardLayout::NativeConstruct()
+{
+    Super::NativeConstruct();
+
+    if (KpiSlot && !KpiWidget)
+    {
+        KpiWidget = CreateWidget<UWidget_KpiTiles>(GetWorld(), UWidget_KpiTiles::StaticClass());
+        KpiSlot->SetContent(KpiWidget);
+    }
+    if (NewsSlot && !NewsWidget)
+    {
+        NewsWidget = CreateWidget<UWidget_NewsFeed>(GetWorld(), UWidget_NewsFeed::StaticClass());
+        NewsSlot->SetContent(NewsWidget);
+    }
+    if (CalendarSlot && !CalendarWidget)
+    {
+        CalendarWidget = CreateWidget<UWidget_ReleaseCalendar>(GetWorld(), UWidget_ReleaseCalendar::StaticClass());
+        CalendarSlot->SetContent(CalendarWidget);
+    }
+    if (HeatmapSlot && !HeatmapWidget)
+    {
+        HeatmapWidget = CreateWidget<UWidget_MarketHeatmap>(GetWorld(), UWidget_MarketHeatmap::StaticClass());
+        HeatmapSlot->SetContent(HeatmapWidget);
+    }
+    if (ActionsSlot && !ActionsWidget)
+    {
+        ActionsWidget = CreateWidget<UWidget_SuggestedActions>(GetWorld(), UWidget_SuggestedActions::StaticClass());
+        ActionsSlot->SetContent(ActionsWidget);
+    }
+
+    if (ViewModel)
+    {
+        KpiWidget->SetMetrics(ViewModel->GetKpiMetrics());
+        NewsWidget->SetNews(ViewModel->GetNews());
+        FDateTime Now = FDateTime::Now();
+        CalendarWidget->SetMonth(Now.GetYear(), Now.GetMonth());
+        CalendarWidget->SetReleases(ViewModel->GetReleases());
+        HeatmapWidget->SetMarketStats(ViewModel->GetMarketStats());
+        ActionsWidget->SetActions(ViewModel->GetActions());
+    }
+}
+
+void UWidget_DashboardLayout::SetViewModel(UDashboardViewModel* InViewModel)
+{
+    ViewModel = InViewModel;
+    if (!ViewModel) return;
+
+    if (KpiWidget) KpiWidget->SetMetrics(ViewModel->GetKpiMetrics());
+    if (NewsWidget) NewsWidget->SetNews(ViewModel->GetNews());
+    if (CalendarWidget)
+    {
+        FDateTime Now = FDateTime::Now();
+        CalendarWidget->SetMonth(Now.GetYear(), Now.GetMonth());
+        CalendarWidget->SetReleases(ViewModel->GetReleases());
+    }
+    if (HeatmapWidget) HeatmapWidget->SetMarketStats(ViewModel->GetMarketStats());
+    if (ActionsWidget) ActionsWidget->SetActions(ViewModel->GetActions());
+}

--- a/Source/LabelManager/Private/UI/Widget_KpiTiles.cpp
+++ b/Source/LabelManager/Private/UI/Widget_KpiTiles.cpp
@@ -1,0 +1,52 @@
+#include "UI/Widget_KpiTiles.h"
+#include "Components/TextBlock.h"
+#include "TimerManager.h"
+
+void UWidget_KpiTiles::NativeConstruct()
+{
+    Super::NativeConstruct();
+
+    if (CashValueText) CashValueText->SetToolTipText(FText::FromString("Available cash"));
+    if (WeeklyStreamsText) WeeklyStreamsText->SetToolTipText(FText::FromString("Streams this week"));
+    if (ChartingTitlesText) ChartingTitlesText->SetToolTipText(FText::FromString("Titles on charts"));
+    if (ActiveCampaignsText) ActiveCampaignsText->SetToolTipText(FText::FromString("Active campaigns"));
+
+    PlayFadeIn();
+}
+
+void UWidget_KpiTiles::SetMetrics(const FKpiMetrics& InMetrics)
+{
+    if (CashValueText)
+    {
+        CashValueText->SetText(FText::AsNumber(InMetrics.Cash));
+    }
+    if (WeeklyStreamsText)
+    {
+        WeeklyStreamsText->SetText(FText::AsNumber(InMetrics.WeeklyStreams));
+    }
+    if (ChartingTitlesText)
+    {
+        ChartingTitlesText->SetText(FText::AsNumber(InMetrics.ChartingTitles));
+    }
+    if (ActiveCampaignsText)
+    {
+        ActiveCampaignsText->SetText(FText::AsNumber(InMetrics.ActiveCampaigns));
+    }
+}
+
+void UWidget_KpiTiles::PlayFadeIn()
+{
+    SetRenderOpacity(0.f);
+    float Opacity = 0.f;
+    FTimerHandle Timer;
+    GetWorld()->GetTimerManager().SetTimer(Timer, [this, Opacity]() mutable
+    {
+        SetRenderOpacity(Opacity);
+        Opacity += 0.1f;
+        if (Opacity >= 1.f)
+        {
+            SetRenderOpacity(1.f);
+            GetWorld()->GetTimerManager().ClearTimer(Timer);
+        }
+    }, 0.05f, true);
+}

--- a/Source/LabelManager/Private/UI/Widget_MarketHeatmap.cpp
+++ b/Source/LabelManager/Private/UI/Widget_MarketHeatmap.cpp
@@ -1,0 +1,45 @@
+#include "UI/Widget_MarketHeatmap.h"
+#include "UI/Widget_MarketRegionEntry.h"
+#include "Components/ListView.h"
+#include "TimerManager.h"
+
+void UWidget_MarketHeatmap::NativeConstruct()
+{
+    Super::NativeConstruct();
+    if (HeatList && !HeatList->GetEntryWidgetClass())
+    {
+        HeatList->SetEntryWidgetClass(UWidget_MarketRegionEntry::StaticClass());
+    }
+    PlayFadeIn();
+}
+
+void UWidget_MarketHeatmap::SetMarketStats(const TArray<FMarketRegionStat>& InStats)
+{
+    if (!HeatList) return;
+    TArray<UObject*> Items;
+    for (const FMarketRegionStat& Stat : InStats)
+    {
+        UMarketRegionObject* Obj = NewObject<UMarketRegionObject>(this);
+        Obj->Stat = Stat;
+        Items.Add(Obj);
+    }
+    HeatList->ClearListItems();
+    HeatList->SetListItems(Items);
+}
+
+void UWidget_MarketHeatmap::PlayFadeIn()
+{
+    SetRenderOpacity(0.f);
+    float Opacity = 0.f;
+    FTimerHandle Timer;
+    GetWorld()->GetTimerManager().SetTimer(Timer, [this, Opacity]() mutable
+    {
+        SetRenderOpacity(Opacity);
+        Opacity += 0.1f;
+        if (Opacity >= 1.f)
+        {
+            SetRenderOpacity(1.f);
+            GetWorld()->GetTimerManager().ClearTimer(Timer);
+        }
+    }, 0.05f, true);
+}

--- a/Source/LabelManager/Private/UI/Widget_MarketRegionEntry.cpp
+++ b/Source/LabelManager/Private/UI/Widget_MarketRegionEntry.cpp
@@ -1,0 +1,36 @@
+#include "UI/Widget_MarketRegionEntry.h"
+#include "Components/TextBlock.h"
+#include "Components/ProgressBar.h"
+#include "TimerManager.h"
+
+void UWidget_MarketRegionEntry::NativeOnListItemObjectSet(UObject* ListItem)
+{
+    UMarketRegionObject* Obj = Cast<UMarketRegionObject>(ListItem);
+    if (Obj && RegionNameText)
+    {
+        RegionNameText->SetText(FText::FromName(Obj->Stat.Region));
+        RegionNameText->SetToolTipText(FText::FromName(Obj->Stat.Region));
+    }
+    if (Obj && IntensityBar)
+    {
+        IntensityBar->SetPercent(Obj->Stat.Intensity01);
+    }
+    PlayFadeIn();
+}
+
+void UWidget_MarketRegionEntry::PlayFadeIn()
+{
+    SetRenderOpacity(0.f);
+    float Opacity = 0.f;
+    FTimerHandle Timer;
+    GetWorld()->GetTimerManager().SetTimer(Timer, [this, Opacity]() mutable
+    {
+        SetRenderOpacity(Opacity);
+        Opacity += 0.1f;
+        if (Opacity >= 1.f)
+        {
+            SetRenderOpacity(1.f);
+            GetWorld()->GetTimerManager().ClearTimer(Timer);
+        }
+    }, 0.05f, true);
+}

--- a/Source/LabelManager/Private/UI/Widget_NewsFeed.cpp
+++ b/Source/LabelManager/Private/UI/Widget_NewsFeed.cpp
@@ -1,0 +1,45 @@
+#include "UI/Widget_NewsFeed.h"
+#include "UI/Widget_NewsItemEntry.h"
+#include "Components/ListView.h"
+#include "TimerManager.h"
+
+void UWidget_NewsFeed::NativeConstruct()
+{
+    Super::NativeConstruct();
+    if (NewsList && !NewsList->GetEntryWidgetClass())
+    {
+        NewsList->SetEntryWidgetClass(UWidget_NewsItemEntry::StaticClass());
+    }
+    PlayFadeIn();
+}
+
+void UWidget_NewsFeed::SetNews(const TArray<FNewsItem>& InNews)
+{
+    if (!NewsList) return;
+    TArray<UObject*> Items;
+    for (const FNewsItem& Item : InNews)
+    {
+        UNewsItemObject* Obj = NewObject<UNewsItemObject>(this);
+        Obj->Item = Item;
+        Items.Add(Obj);
+    }
+    NewsList->ClearListItems();
+    NewsList->SetListItems(Items);
+}
+
+void UWidget_NewsFeed::PlayFadeIn()
+{
+    SetRenderOpacity(0.f);
+    float Opacity = 0.f;
+    FTimerHandle Timer;
+    GetWorld()->GetTimerManager().SetTimer(Timer, [this, Opacity]() mutable
+    {
+        SetRenderOpacity(Opacity);
+        Opacity += 0.1f;
+        if (Opacity >= 1.f)
+        {
+            SetRenderOpacity(1.f);
+            GetWorld()->GetTimerManager().ClearTimer(Timer);
+        }
+    }, 0.05f, true);
+}

--- a/Source/LabelManager/Private/UI/Widget_NewsItemEntry.cpp
+++ b/Source/LabelManager/Private/UI/Widget_NewsItemEntry.cpp
@@ -1,0 +1,35 @@
+#include "UI/Widget_NewsItemEntry.h"
+#include "Components/TextBlock.h"
+#include "TimerManager.h"
+
+void UWidget_NewsItemEntry::NativeOnListItemObjectSet(UObject* ListItem)
+{
+    UNewsItemObject* Obj = Cast<UNewsItemObject>(ListItem);
+    if (Obj && HeadlineText)
+    {
+        HeadlineText->SetText(Obj->Item.Headline);
+        HeadlineText->SetToolTipText(Obj->Item.Headline);
+    }
+    if (Obj && DateText)
+    {
+        DateText->SetText(FText::AsDate(Obj->Item.Date));
+    }
+    PlayFadeIn();
+}
+
+void UWidget_NewsItemEntry::PlayFadeIn()
+{
+    SetRenderOpacity(0.f);
+    float Opacity = 0.f;
+    FTimerHandle Timer;
+    GetWorld()->GetTimerManager().SetTimer(Timer, [this, Opacity]() mutable
+    {
+        SetRenderOpacity(Opacity);
+        Opacity += 0.1f;
+        if (Opacity >= 1.f)
+        {
+            SetRenderOpacity(1.f);
+            GetWorld()->GetTimerManager().ClearTimer(Timer);
+        }
+    }, 0.05f, true);
+}

--- a/Source/LabelManager/Private/UI/Widget_ReleaseCalendar.cpp
+++ b/Source/LabelManager/Private/UI/Widget_ReleaseCalendar.cpp
@@ -1,0 +1,69 @@
+#include "UI/Widget_ReleaseCalendar.h"
+#include "UI/Widget_ReleaseItemEntry.h"
+#include "Components/TextBlock.h"
+#include "Components/Button.h"
+#include "Components/UniformGridPanel.h"
+#include "Components/ListView.h"
+#include "Blueprint/WidgetTree.h"
+#include "TimerManager.h"
+
+void UWidget_ReleaseCalendar::NativeConstruct()
+{
+    Super::NativeConstruct();
+    if (UpcomingList && !UpcomingList->GetEntryWidgetClass())
+    {
+        UpcomingList->SetEntryWidgetClass(UWidget_ReleaseItemEntry::StaticClass());
+    }
+    PlayFadeIn();
+}
+
+void UWidget_ReleaseCalendar::SetMonth(int32 Year, int32 Month)
+{
+    if (MonthLabel)
+    {
+        FDateTime Date(Year, Month, 1);
+        MonthLabel->SetText(FText::FromString(Date.ToString(TEXT("%B %Y"))));
+    }
+    if (CalendarGrid)
+    {
+        CalendarGrid->ClearChildren();
+        int32 Days = FDateTime::DaysInMonth(Year, Month);
+        for (int32 Day = 1; Day <= Days; ++Day)
+        {
+            UTextBlock* DayText = WidgetTree->ConstructWidget<UTextBlock>(UTextBlock::StaticClass());
+            DayText->SetText(FText::AsNumber(Day));
+            CalendarGrid->AddChildToUniformGrid(DayText, (Day - 1) / 7, (Day - 1) % 7);
+        }
+    }
+}
+
+void UWidget_ReleaseCalendar::SetReleases(const TArray<FReleaseItem>& InReleases)
+{
+    if (!UpcomingList) return;
+    TArray<UObject*> Items;
+    for (const FReleaseItem& Item : InReleases)
+    {
+        UReleaseItemObject* Obj = NewObject<UReleaseItemObject>(this);
+        Obj->Item = Item;
+        Items.Add(Obj);
+    }
+    UpcomingList->ClearListItems();
+    UpcomingList->SetListItems(Items);
+}
+
+void UWidget_ReleaseCalendar::PlayFadeIn()
+{
+    SetRenderOpacity(0.f);
+    float Opacity = 0.f;
+    FTimerHandle Timer;
+    GetWorld()->GetTimerManager().SetTimer(Timer, [this, Opacity]() mutable
+    {
+        SetRenderOpacity(Opacity);
+        Opacity += 0.1f;
+        if (Opacity >= 1.f)
+        {
+            SetRenderOpacity(1.f);
+            GetWorld()->GetTimerManager().ClearTimer(Timer);
+        }
+    }, 0.05f, true);
+}

--- a/Source/LabelManager/Private/UI/Widget_ReleaseItemEntry.cpp
+++ b/Source/LabelManager/Private/UI/Widget_ReleaseItemEntry.cpp
@@ -1,0 +1,38 @@
+#include "UI/Widget_ReleaseItemEntry.h"
+#include "Components/TextBlock.h"
+#include "TimerManager.h"
+
+void UWidget_ReleaseItemEntry::NativeOnListItemObjectSet(UObject* ListItem)
+{
+    UReleaseItemObject* Obj = Cast<UReleaseItemObject>(ListItem);
+    if (Obj && TitleText)
+    {
+        TitleText->SetText(Obj->Item.Title);
+    }
+    if (Obj && TypeText)
+    {
+        TypeText->SetText(Obj->Item.Type);
+    }
+    if (Obj && DateText)
+    {
+        DateText->SetText(FText::AsDate(Obj->Item.Date));
+    }
+    PlayFadeIn();
+}
+
+void UWidget_ReleaseItemEntry::PlayFadeIn()
+{
+    SetRenderOpacity(0.f);
+    float Opacity = 0.f;
+    FTimerHandle Timer;
+    GetWorld()->GetTimerManager().SetTimer(Timer, [this, Opacity]() mutable
+    {
+        SetRenderOpacity(Opacity);
+        Opacity += 0.1f;
+        if (Opacity >= 1.f)
+        {
+            SetRenderOpacity(1.f);
+            GetWorld()->GetTimerManager().ClearTimer(Timer);
+        }
+    }, 0.05f, true);
+}

--- a/Source/LabelManager/Private/UI/Widget_SuggestedActions.cpp
+++ b/Source/LabelManager/Private/UI/Widget_SuggestedActions.cpp
@@ -1,0 +1,45 @@
+#include "UI/Widget_SuggestedActions.h"
+#include "UI/Widget_ActionEntry.h"
+#include "Components/ListView.h"
+#include "TimerManager.h"
+
+void UWidget_SuggestedActions::NativeConstruct()
+{
+    Super::NativeConstruct();
+    if (ActionsList && !ActionsList->GetEntryWidgetClass())
+    {
+        ActionsList->SetEntryWidgetClass(UWidget_ActionEntry::StaticClass());
+    }
+    PlayFadeIn();
+}
+
+void UWidget_SuggestedActions::SetActions(const TArray<FSuggestedAction>& InActions)
+{
+    if (!ActionsList) return;
+    TArray<UObject*> Items;
+    for (const FSuggestedAction& Action : InActions)
+    {
+        USuggestedActionObject* Obj = NewObject<USuggestedActionObject>(this);
+        Obj->Action = Action;
+        Items.Add(Obj);
+    }
+    ActionsList->ClearListItems();
+    ActionsList->SetListItems(Items);
+}
+
+void UWidget_SuggestedActions::PlayFadeIn()
+{
+    SetRenderOpacity(0.f);
+    float Opacity = 0.f;
+    FTimerHandle Timer;
+    GetWorld()->GetTimerManager().SetTimer(Timer, [this, Opacity]() mutable
+    {
+        SetRenderOpacity(Opacity);
+        Opacity += 0.1f;
+        if (Opacity >= 1.f)
+        {
+            SetRenderOpacity(1.f);
+            GetWorld()->GetTimerManager().ClearTimer(Timer);
+        }
+    }, 0.05f, true);
+}

--- a/Source/LabelManager/Public/Style/LabelUIStyle.h
+++ b/Source/LabelManager/Public/Style/LabelUIStyle.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Styling/SlateStyle.h"
+
+class FLabelUIStyle : public FSlateStyleSet
+{
+public:
+    FLabelUIStyle();
+
+    static void Initialize();
+    static void Shutdown();
+    static const ISlateStyle& Get();
+    static FName GetStyleSetName();
+
+    // Colors
+    FLinearColor ColorBackground;
+    FLinearColor ColorPanel;
+    FLinearColor ColorAccent;
+    FLinearColor ColorTextDim;
+
+    // Text styles
+    FTextBlockStyle Heading;
+    FTextBlockStyle TileNumber;
+    FTextBlockStyle Body;
+
+    // Padding
+    FMargin StandardPadding;
+
+private:
+    static TSharedPtr<FLabelUIStyle> Instance;
+};

--- a/Source/LabelManager/Public/UI/DashboardViewModel.h
+++ b/Source/LabelManager/Public/UI/DashboardViewModel.h
@@ -1,0 +1,98 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "UObject/NoExportTypes.h"
+#include "DashboardViewModel.generated.h"
+
+USTRUCT(BlueprintType)
+struct FKpiMetrics
+{
+    GENERATED_BODY()
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite)
+    double Cash = 0.0;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite)
+    int32 WeeklyStreams = 0;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite)
+    int32 ChartingTitles = 0;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite)
+    int32 ActiveCampaigns = 0;
+};
+
+USTRUCT(BlueprintType)
+struct FNewsItem
+{
+    GENERATED_BODY()
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite)
+    FText Headline;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite)
+    FDateTime Date;
+};
+
+USTRUCT(BlueprintType)
+struct FReleaseItem
+{
+    GENERATED_BODY()
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite)
+    FText Title;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite)
+    FText Type;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite)
+    FDateTime Date;
+};
+
+USTRUCT(BlueprintType)
+struct FMarketRegionStat
+{
+    GENERATED_BODY()
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite)
+    FName Region;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite)
+    float Intensity01 = 0.f;
+};
+
+USTRUCT(BlueprintType)
+struct FSuggestedAction
+{
+    GENERATED_BODY()
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite)
+    FText Label;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite)
+    FName ActionId;
+};
+
+UCLASS(BlueprintType)
+class LABELMANAGER_API UDashboardViewModel : public UObject
+{
+    GENERATED_BODY()
+public:
+    UDashboardViewModel();
+
+    const FKpiMetrics& GetKpiMetrics() const { return Kpi; }
+    const TArray<FNewsItem>& GetNews() const { return News; }
+    const TArray<FReleaseItem>& GetReleases() const { return Releases; }
+    const TArray<FMarketRegionStat>& GetMarketStats() const { return MarketStats; }
+    const TArray<FSuggestedAction>& GetActions() const { return Actions; }
+
+    UFUNCTION(BlueprintCallable)
+    void RefreshAll();
+
+private:
+    FKpiMetrics Kpi;
+    TArray<FNewsItem> News;
+    TArray<FReleaseItem> Releases;
+    TArray<FMarketRegionStat> MarketStats;
+    TArray<FSuggestedAction> Actions;
+};

--- a/Source/LabelManager/Public/UI/WidgetLibrary.h
+++ b/Source/LabelManager/Public/UI/WidgetLibrary.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "Kismet/BlueprintFunctionLibrary.h"
+#include "WidgetLibrary.generated.h"
+
+class UWidget_DashboardLayout;
+class UDashboardViewModel;
+class APlayerController;
+
+UCLASS()
+class LABELMANAGER_API UWidgetLibrary : public UBlueprintFunctionLibrary
+{
+    GENERATED_BODY()
+public:
+    UFUNCTION(BlueprintCallable, Category="LabelUI", meta=(WorldContext="World"))
+    static UWidget_DashboardLayout* CreateDashboard(UWorld* World, APlayerController* PC);
+};

--- a/Source/LabelManager/Public/UI/Widget_ActionEntry.h
+++ b/Source/LabelManager/Public/UI/Widget_ActionEntry.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Blueprint/UserWidget.h"
+#include "Blueprint/IUserObjectListEntry.h"
+#include "Widget_SuggestedActions.h"
+#include "Widget_ActionEntry.generated.h"
+
+class UTextBlock;
+class UButton;
+
+UCLASS()
+class LABELMANAGER_API UWidget_ActionEntry : public UUserWidget, public IUserObjectListEntry
+{
+    GENERATED_BODY()
+public:
+    virtual void NativeOnListItemObjectSet(UObject* ListItem) override;
+
+protected:
+    UPROPERTY(meta=(BindWidget))
+    UTextBlock* ActionLabelText;
+
+    UPROPERTY(meta=(BindWidget))
+    UButton* GoButton;
+
+    void PlayFadeIn();
+};

--- a/Source/LabelManager/Public/UI/Widget_DashboardLayout.h
+++ b/Source/LabelManager/Public/UI/Widget_DashboardLayout.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Blueprint/UserWidget.h"
+#include "Widget_DashboardLayout.generated.h"
+
+class UCanvasPanel;
+class UGridPanel;
+class USizeBox;
+class UDashboardViewModel;
+class UWidget_KpiTiles;
+class UWidget_NewsFeed;
+class UWidget_ReleaseCalendar;
+class UWidget_MarketHeatmap;
+class UWidget_SuggestedActions;
+
+UCLASS(BlueprintType)
+class LABELMANAGER_API UWidget_DashboardLayout : public UUserWidget
+{
+    GENERATED_BODY()
+public:
+    virtual void NativeConstruct() override;
+
+    UFUNCTION(BlueprintCallable)
+    void SetViewModel(UDashboardViewModel* InViewModel);
+
+protected:
+    UPROPERTY(meta=(BindWidget))
+    UCanvasPanel* RootCanvas;
+
+    UPROPERTY(meta=(BindWidget))
+    UGridPanel* Grid;
+
+    UPROPERTY(meta=(BindWidget))
+    USizeBox* KpiSlot;
+
+    UPROPERTY(meta=(BindWidget))
+    USizeBox* NewsSlot;
+
+    UPROPERTY(meta=(BindWidget))
+    USizeBox* CalendarSlot;
+
+    UPROPERTY(meta=(BindWidget))
+    USizeBox* HeatmapSlot;
+
+    UPROPERTY(meta=(BindWidget))
+    USizeBox* ActionsSlot;
+
+    UPROPERTY()
+    UWidget_KpiTiles* KpiWidget;
+
+    UPROPERTY()
+    UWidget_NewsFeed* NewsWidget;
+
+    UPROPERTY()
+    UWidget_ReleaseCalendar* CalendarWidget;
+
+    UPROPERTY()
+    UWidget_MarketHeatmap* HeatmapWidget;
+
+    UPROPERTY()
+    UWidget_SuggestedActions* ActionsWidget;
+
+    UPROPERTY()
+    UDashboardViewModel* ViewModel;
+};

--- a/Source/LabelManager/Public/UI/Widget_KpiTiles.h
+++ b/Source/LabelManager/Public/UI/Widget_KpiTiles.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Blueprint/UserWidget.h"
+#include "DashboardViewModel.h"
+#include "Widget_KpiTiles.generated.h"
+
+class UTextBlock;
+
+UCLASS(BlueprintType)
+class LABELMANAGER_API UWidget_KpiTiles : public UUserWidget
+{
+    GENERATED_BODY()
+public:
+    virtual void NativeConstruct() override;
+
+    UFUNCTION(BlueprintCallable)
+    void SetMetrics(const FKpiMetrics& InMetrics);
+
+protected:
+    UPROPERTY(meta=(BindWidget))
+    UTextBlock* CashValueText;
+
+    UPROPERTY(meta=(BindWidget))
+    UTextBlock* WeeklyStreamsText;
+
+    UPROPERTY(meta=(BindWidget))
+    UTextBlock* ChartingTitlesText;
+
+    UPROPERTY(meta=(BindWidget))
+    UTextBlock* ActiveCampaignsText;
+
+    void PlayFadeIn();
+};

--- a/Source/LabelManager/Public/UI/Widget_MarketHeatmap.h
+++ b/Source/LabelManager/Public/UI/Widget_MarketHeatmap.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Blueprint/UserWidget.h"
+#include "DashboardViewModel.h"
+#include "Widget_MarketHeatmap.generated.h"
+
+class UListView;
+
+UCLASS()
+class UMarketRegionObject : public UObject
+{
+    GENERATED_BODY()
+public:
+    FMarketRegionStat Stat;
+};
+
+UCLASS(BlueprintType)
+class LABELMANAGER_API UWidget_MarketHeatmap : public UUserWidget
+{
+    GENERATED_BODY()
+public:
+    virtual void NativeConstruct() override;
+
+    UFUNCTION(BlueprintCallable)
+    void SetMarketStats(const TArray<FMarketRegionStat>& InStats);
+
+protected:
+    UPROPERTY(meta=(BindWidget))
+    UListView* HeatList;
+
+    void PlayFadeIn();
+};

--- a/Source/LabelManager/Public/UI/Widget_MarketRegionEntry.h
+++ b/Source/LabelManager/Public/UI/Widget_MarketRegionEntry.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Blueprint/UserWidget.h"
+#include "Blueprint/IUserObjectListEntry.h"
+#include "Widget_MarketHeatmap.h"
+#include "Widget_MarketRegionEntry.generated.h"
+
+class UTextBlock;
+class UProgressBar;
+
+UCLASS()
+class LABELMANAGER_API UWidget_MarketRegionEntry : public UUserWidget, public IUserObjectListEntry
+{
+    GENERATED_BODY()
+public:
+    virtual void NativeOnListItemObjectSet(UObject* ListItem) override;
+
+protected:
+    UPROPERTY(meta=(BindWidget))
+    UTextBlock* RegionNameText;
+
+    UPROPERTY(meta=(BindWidget))
+    UProgressBar* IntensityBar;
+
+    void PlayFadeIn();
+};

--- a/Source/LabelManager/Public/UI/Widget_NewsFeed.h
+++ b/Source/LabelManager/Public/UI/Widget_NewsFeed.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Blueprint/UserWidget.h"
+#include "DashboardViewModel.h"
+#include "Widget_NewsFeed.generated.h"
+
+class UListView;
+
+UCLASS()
+class UNewsItemObject : public UObject
+{
+    GENERATED_BODY()
+public:
+    FNewsItem Item;
+};
+
+UCLASS(BlueprintType)
+class LABELMANAGER_API UWidget_NewsFeed : public UUserWidget
+{
+    GENERATED_BODY()
+public:
+    virtual void NativeConstruct() override;
+
+    UFUNCTION(BlueprintCallable)
+    void SetNews(const TArray<FNewsItem>& InNews);
+
+protected:
+    UPROPERTY(meta=(BindWidget))
+    UListView* NewsList;
+
+    void PlayFadeIn();
+};

--- a/Source/LabelManager/Public/UI/Widget_NewsItemEntry.h
+++ b/Source/LabelManager/Public/UI/Widget_NewsItemEntry.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Blueprint/UserWidget.h"
+#include "Blueprint/IUserObjectListEntry.h"
+#include "Widget_NewsFeed.h"
+#include "Widget_NewsItemEntry.generated.h"
+
+class UTextBlock;
+
+UCLASS()
+class LABELMANAGER_API UWidget_NewsItemEntry : public UUserWidget, public IUserObjectListEntry
+{
+    GENERATED_BODY()
+public:
+    virtual void NativeOnListItemObjectSet(UObject* ListItem) override;
+
+protected:
+    UPROPERTY(meta=(BindWidget))
+    UTextBlock* HeadlineText;
+
+    UPROPERTY(meta=(BindWidget))
+    UTextBlock* DateText;
+
+    void PlayFadeIn();
+};

--- a/Source/LabelManager/Public/UI/Widget_ReleaseCalendar.h
+++ b/Source/LabelManager/Public/UI/Widget_ReleaseCalendar.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Blueprint/UserWidget.h"
+#include "DashboardViewModel.h"
+#include "Widget_ReleaseCalendar.generated.h"
+
+class UTextBlock;
+class UButton;
+class UUniformGridPanel;
+class UListView;
+
+UCLASS()
+class UReleaseItemObject : public UObject
+{
+    GENERATED_BODY()
+public:
+    FReleaseItem Item;
+};
+
+UCLASS(BlueprintType)
+class LABELMANAGER_API UWidget_ReleaseCalendar : public UUserWidget
+{
+    GENERATED_BODY()
+public:
+    virtual void NativeConstruct() override;
+
+    UFUNCTION(BlueprintCallable)
+    void SetMonth(int32 Year, int32 Month);
+
+    UFUNCTION(BlueprintCallable)
+    void SetReleases(const TArray<FReleaseItem>& InReleases);
+
+protected:
+    UPROPERTY(meta=(BindWidget))
+    UTextBlock* MonthLabel;
+
+    UPROPERTY(meta=(BindWidget))
+    UButton* PrevMonthBtn;
+
+    UPROPERTY(meta=(BindWidget))
+    UButton* NextMonthBtn;
+
+    UPROPERTY(meta=(BindWidget))
+    UUniformGridPanel* CalendarGrid;
+
+    UPROPERTY(meta=(BindWidget))
+    UListView* UpcomingList;
+
+    void PlayFadeIn();
+};

--- a/Source/LabelManager/Public/UI/Widget_ReleaseItemEntry.h
+++ b/Source/LabelManager/Public/UI/Widget_ReleaseItemEntry.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Blueprint/UserWidget.h"
+#include "Blueprint/IUserObjectListEntry.h"
+#include "Widget_ReleaseCalendar.h"
+#include "Widget_ReleaseItemEntry.generated.h"
+
+class UTextBlock;
+
+UCLASS()
+class LABELMANAGER_API UWidget_ReleaseItemEntry : public UUserWidget, public IUserObjectListEntry
+{
+    GENERATED_BODY()
+public:
+    virtual void NativeOnListItemObjectSet(UObject* ListItem) override;
+
+protected:
+    UPROPERTY(meta=(BindWidget))
+    UTextBlock* TitleText;
+
+    UPROPERTY(meta=(BindWidget))
+    UTextBlock* TypeText;
+
+    UPROPERTY(meta=(BindWidget))
+    UTextBlock* DateText;
+
+    void PlayFadeIn();
+};

--- a/Source/LabelManager/Public/UI/Widget_SuggestedActions.h
+++ b/Source/LabelManager/Public/UI/Widget_SuggestedActions.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Blueprint/UserWidget.h"
+#include "DashboardViewModel.h"
+#include "Widget_SuggestedActions.generated.h"
+
+class UListView;
+
+UCLASS()
+class USuggestedActionObject : public UObject
+{
+    GENERATED_BODY()
+public:
+    FSuggestedAction Action;
+};
+
+UCLASS(BlueprintType)
+class LABELMANAGER_API UWidget_SuggestedActions : public UUserWidget
+{
+    GENERATED_BODY()
+public:
+    virtual void NativeConstruct() override;
+
+    UFUNCTION(BlueprintCallable)
+    void SetActions(const TArray<FSuggestedAction>& InActions);
+
+protected:
+    UPROPERTY(meta=(BindWidget))
+    UListView* ActionsList;
+
+    void PlayFadeIn();
+};


### PR DESCRIPTION
## Summary
- Add Label UI style set and initialize during module startup
- Implement dashboard view model with sample KPI, news, release, market, and action data
- Add dashboard layout and child widgets for KPIs, news feed, release calendar, market heatmap, and suggested actions
- Provide helper library to spawn dashboard UI and updated module build dependencies and config

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68add75b7efc832ea92a51f611df69c8