### PR TITLE
Fix compile errors and list view initialization

### DIFF
--- a/Source/LabelManager/Private/Style/LabelUIStyle.cpp
+++ b/Source/LabelManager/Private/Style/LabelUIStyle.cpp
@@ -5,7 +5,7 @@
 TSharedPtr<FLabelUIStyle> FLabelUIStyle::Instance = nullptr;
 
 FLabelUIStyle::FLabelUIStyle()
-    : FSlateStyleSet(GetStyleSetName())
+    : FSlateStyleSet(GetStyleName())
 {
     ColorBackground = FLinearColor(0.05f, 0.05f, 0.05f);
     ColorPanel = FLinearColor(0.1f, 0.1f, 0.1f);
@@ -50,7 +50,7 @@ const ISlateStyle& FLabelUIStyle::Get()
     return *Instance;
 }
 
-FName FLabelUIStyle::GetStyleSetName()
+FName FLabelUIStyle::GetStyleName()
 {
     static FName StyleName(TEXT("LabelUIStyle"));
     return StyleName;

--- a/Source/LabelManager/Private/UI/DashboardViewModel.cpp
+++ b/Source/LabelManager/Private/UI/DashboardViewModel.cpp
@@ -14,11 +14,11 @@ void UDashboardViewModel::RefreshAll()
 
     News.Reset();
     News.Add({FText::FromString("Artist A tops charts"), FDateTime::UtcNow()});
-    News.Add({FText::FromString("Label signs new talent"), FDateTime::UtcNow().AddDays(-1)});
+    News.Add({FText::FromString("Label signs new talent"), FDateTime::UtcNow() - FTimespan::FromDays(1)});
 
     Releases.Reset();
-    Releases.Add({FText::FromString("Album X"), FText::FromString("LP"), FDateTime::UtcNow().AddDays(5)});
-    Releases.Add({FText::FromString("Single Y"), FText::FromString("Single"), FDateTime::UtcNow().AddDays(12)});
+    Releases.Add({FText::FromString("Album X"), FText::FromString("LP"), FDateTime::UtcNow() + FTimespan::FromDays(5)});
+    Releases.Add({FText::FromString("Single Y"), FText::FromString("Single"), FDateTime::UtcNow() + FTimespan::FromDays(12)});
 
     MarketStats.Reset();
     MarketStats.Add({FName("NorthAmerica"), 0.8f});

--- a/Source/LabelManager/Private/UI/Widget_ActionEntry.cpp
+++ b/Source/LabelManager/Private/UI/Widget_ActionEntry.cpp
@@ -18,15 +18,14 @@ void UWidget_ActionEntry::PlayFadeIn()
 {
     SetRenderOpacity(0.f);
     float Opacity = 0.f;
-    FTimerHandle Timer;
-    GetWorld()->GetTimerManager().SetTimer(Timer, [this, Opacity]() mutable
+    GetWorld()->GetTimerManager().SetTimer(FadeTimer, [this, Opacity]() mutable
     {
         SetRenderOpacity(Opacity);
         Opacity += 0.1f;
         if (Opacity >= 1.f)
         {
             SetRenderOpacity(1.f);
-            GetWorld()->GetTimerManager().ClearTimer(Timer);
+            GetWorld()->GetTimerManager().ClearTimer(FadeTimer);
         }
     }, 0.05f, true);
 }

--- a/Source/LabelManager/Private/UI/Widget_KpiTiles.cpp
+++ b/Source/LabelManager/Private/UI/Widget_KpiTiles.cpp
@@ -38,15 +38,14 @@ void UWidget_KpiTiles::PlayFadeIn()
 {
     SetRenderOpacity(0.f);
     float Opacity = 0.f;
-    FTimerHandle Timer;
-    GetWorld()->GetTimerManager().SetTimer(Timer, [this, Opacity]() mutable
+    GetWorld()->GetTimerManager().SetTimer(FadeTimer, [this, Opacity]() mutable
     {
         SetRenderOpacity(Opacity);
         Opacity += 0.1f;
         if (Opacity >= 1.f)
         {
             SetRenderOpacity(1.f);
-            GetWorld()->GetTimerManager().ClearTimer(Timer);
+            GetWorld()->GetTimerManager().ClearTimer(FadeTimer);
         }
     }, 0.05f, true);
 }

--- a/Source/LabelManager/Private/UI/Widget_MarketHeatmap.cpp
+++ b/Source/LabelManager/Private/UI/Widget_MarketHeatmap.cpp
@@ -6,9 +6,9 @@
 void UWidget_MarketHeatmap::NativeConstruct()
 {
     Super::NativeConstruct();
-    if (HeatList && !HeatList->GetEntryWidgetClass())
+    if (HeatList && !HeatList->EntryWidgetClass)
     {
-        HeatList->SetEntryWidgetClass(UWidget_MarketRegionEntry::StaticClass());
+        HeatList->EntryWidgetClass = UWidget_MarketRegionEntry::StaticClass();
     }
     PlayFadeIn();
 }
@@ -31,15 +31,14 @@ void UWidget_MarketHeatmap::PlayFadeIn()
 {
     SetRenderOpacity(0.f);
     float Opacity = 0.f;
-    FTimerHandle Timer;
-    GetWorld()->GetTimerManager().SetTimer(Timer, [this, Opacity]() mutable
+    GetWorld()->GetTimerManager().SetTimer(FadeTimer, [this, Opacity]() mutable
     {
         SetRenderOpacity(Opacity);
         Opacity += 0.1f;
         if (Opacity >= 1.f)
         {
             SetRenderOpacity(1.f);
-            GetWorld()->GetTimerManager().ClearTimer(Timer);
+            GetWorld()->GetTimerManager().ClearTimer(FadeTimer);
         }
     }, 0.05f, true);
 }

--- a/Source/LabelManager/Private/UI/Widget_MarketRegionEntry.cpp
+++ b/Source/LabelManager/Private/UI/Widget_MarketRegionEntry.cpp
@@ -22,15 +22,14 @@ void UWidget_MarketRegionEntry::PlayFadeIn()
 {
     SetRenderOpacity(0.f);
     float Opacity = 0.f;
-    FTimerHandle Timer;
-    GetWorld()->GetTimerManager().SetTimer(Timer, [this, Opacity]() mutable
+    GetWorld()->GetTimerManager().SetTimer(FadeTimer, [this, Opacity]() mutable
     {
         SetRenderOpacity(Opacity);
         Opacity += 0.1f;
         if (Opacity >= 1.f)
         {
             SetRenderOpacity(1.f);
-            GetWorld()->GetTimerManager().ClearTimer(Timer);
+            GetWorld()->GetTimerManager().ClearTimer(FadeTimer);
         }
     }, 0.05f, true);
 }

--- a/Source/LabelManager/Private/UI/Widget_NewsFeed.cpp
+++ b/Source/LabelManager/Private/UI/Widget_NewsFeed.cpp
@@ -6,9 +6,9 @@
 void UWidget_NewsFeed::NativeConstruct()
 {
     Super::NativeConstruct();
-    if (NewsList && !NewsList->GetEntryWidgetClass())
+    if (NewsList && !NewsList->EntryWidgetClass)
     {
-        NewsList->SetEntryWidgetClass(UWidget_NewsItemEntry::StaticClass());
+        NewsList->EntryWidgetClass = UWidget_NewsItemEntry::StaticClass();
     }
     PlayFadeIn();
 }
@@ -31,15 +31,14 @@ void UWidget_NewsFeed::PlayFadeIn()
 {
     SetRenderOpacity(0.f);
     float Opacity = 0.f;
-    FTimerHandle Timer;
-    GetWorld()->GetTimerManager().SetTimer(Timer, [this, Opacity]() mutable
+    GetWorld()->GetTimerManager().SetTimer(FadeTimer, [this, Opacity]() mutable
     {
         SetRenderOpacity(Opacity);
         Opacity += 0.1f;
         if (Opacity >= 1.f)
         {
             SetRenderOpacity(1.f);
-            GetWorld()->GetTimerManager().ClearTimer(Timer);
+            GetWorld()->GetTimerManager().ClearTimer(FadeTimer);
         }
     }, 0.05f, true);
 }

--- a/Source/LabelManager/Private/UI/Widget_NewsItemEntry.cpp
+++ b/Source/LabelManager/Private/UI/Widget_NewsItemEntry.cpp
@@ -21,15 +21,14 @@ void UWidget_NewsItemEntry::PlayFadeIn()
 {
     SetRenderOpacity(0.f);
     float Opacity = 0.f;
-    FTimerHandle Timer;
-    GetWorld()->GetTimerManager().SetTimer(Timer, [this, Opacity]() mutable
+    GetWorld()->GetTimerManager().SetTimer(FadeTimer, [this, Opacity]() mutable
     {
         SetRenderOpacity(Opacity);
         Opacity += 0.1f;
         if (Opacity >= 1.f)
         {
             SetRenderOpacity(1.f);
-            GetWorld()->GetTimerManager().ClearTimer(Timer);
+            GetWorld()->GetTimerManager().ClearTimer(FadeTimer);
         }
     }, 0.05f, true);
 }

--- a/Source/LabelManager/Private/UI/Widget_ReleaseCalendar.cpp
+++ b/Source/LabelManager/Private/UI/Widget_ReleaseCalendar.cpp
@@ -10,9 +10,9 @@
 void UWidget_ReleaseCalendar::NativeConstruct()
 {
     Super::NativeConstruct();
-    if (UpcomingList && !UpcomingList->GetEntryWidgetClass())
+    if (UpcomingList && !UpcomingList->EntryWidgetClass)
     {
-        UpcomingList->SetEntryWidgetClass(UWidget_ReleaseItemEntry::StaticClass());
+        UpcomingList->EntryWidgetClass = UWidget_ReleaseItemEntry::StaticClass();
     }
     PlayFadeIn();
 }
@@ -55,15 +55,14 @@ void UWidget_ReleaseCalendar::PlayFadeIn()
 {
     SetRenderOpacity(0.f);
     float Opacity = 0.f;
-    FTimerHandle Timer;
-    GetWorld()->GetTimerManager().SetTimer(Timer, [this, Opacity]() mutable
+    GetWorld()->GetTimerManager().SetTimer(FadeTimer, [this, Opacity]() mutable
     {
         SetRenderOpacity(Opacity);
         Opacity += 0.1f;
         if (Opacity >= 1.f)
         {
             SetRenderOpacity(1.f);
-            GetWorld()->GetTimerManager().ClearTimer(Timer);
+            GetWorld()->GetTimerManager().ClearTimer(FadeTimer);
         }
     }, 0.05f, true);
 }

--- a/Source/LabelManager/Private/UI/Widget_ReleaseItemEntry.cpp
+++ b/Source/LabelManager/Private/UI/Widget_ReleaseItemEntry.cpp
@@ -24,15 +24,14 @@ void UWidget_ReleaseItemEntry::PlayFadeIn()
 {
     SetRenderOpacity(0.f);
     float Opacity = 0.f;
-    FTimerHandle Timer;
-    GetWorld()->GetTimerManager().SetTimer(Timer, [this, Opacity]() mutable
+    GetWorld()->GetTimerManager().SetTimer(FadeTimer, [this, Opacity]() mutable
     {
         SetRenderOpacity(Opacity);
         Opacity += 0.1f;
         if (Opacity >= 1.f)
         {
             SetRenderOpacity(1.f);
-            GetWorld()->GetTimerManager().ClearTimer(Timer);
+            GetWorld()->GetTimerManager().ClearTimer(FadeTimer);
         }
     }, 0.05f, true);
 }

--- a/Source/LabelManager/Private/UI/Widget_SuggestedActions.cpp
+++ b/Source/LabelManager/Private/UI/Widget_SuggestedActions.cpp
@@ -6,9 +6,9 @@
 void UWidget_SuggestedActions::NativeConstruct()
 {
     Super::NativeConstruct();
-    if (ActionsList && !ActionsList->GetEntryWidgetClass())
+    if (ActionsList && !ActionsList->EntryWidgetClass)
     {
-        ActionsList->SetEntryWidgetClass(UWidget_ActionEntry::StaticClass());
+        ActionsList->EntryWidgetClass = UWidget_ActionEntry::StaticClass();
     }
     PlayFadeIn();
 }
@@ -31,15 +31,14 @@ void UWidget_SuggestedActions::PlayFadeIn()
 {
     SetRenderOpacity(0.f);
     float Opacity = 0.f;
-    FTimerHandle Timer;
-    GetWorld()->GetTimerManager().SetTimer(Timer, [this, Opacity]() mutable
+    GetWorld()->GetTimerManager().SetTimer(FadeTimer, [this, Opacity]() mutable
     {
         SetRenderOpacity(Opacity);
         Opacity += 0.1f;
         if (Opacity >= 1.f)
         {
             SetRenderOpacity(1.f);
-            GetWorld()->GetTimerManager().ClearTimer(Timer);
+            GetWorld()->GetTimerManager().ClearTimer(FadeTimer);
         }
     }, 0.05f, true);
 }

--- a/Source/LabelManager/Public/Style/LabelUIStyle.h
+++ b/Source/LabelManager/Public/Style/LabelUIStyle.h
@@ -11,7 +11,7 @@ public:
     static void Initialize();
     static void Shutdown();
     static const ISlateStyle& Get();
-    static FName GetStyleSetName();
+    static FName GetStyleName();
 
     // Colors
     FLinearColor ColorBackground;

--- a/Source/LabelManager/Public/UI/Widget_ActionEntry.h
+++ b/Source/LabelManager/Public/UI/Widget_ActionEntry.h
@@ -8,6 +8,7 @@
 
 class UTextBlock;
 class UButton;
+struct FTimerHandle;
 
 UCLASS()
 class LABELMANAGER_API UWidget_ActionEntry : public UUserWidget, public IUserObjectListEntry
@@ -24,4 +25,6 @@ protected:
     UButton* GoButton;
 
     void PlayFadeIn();
+
+    FTimerHandle FadeTimer;
 };

--- a/Source/LabelManager/Public/UI/Widget_KpiTiles.h
+++ b/Source/LabelManager/Public/UI/Widget_KpiTiles.h
@@ -6,6 +6,7 @@
 #include "Widget_KpiTiles.generated.h"
 
 class UTextBlock;
+struct FTimerHandle;
 
 UCLASS(BlueprintType)
 class LABELMANAGER_API UWidget_KpiTiles : public UUserWidget
@@ -31,4 +32,6 @@ protected:
     UTextBlock* ActiveCampaignsText;
 
     void PlayFadeIn();
+
+    FTimerHandle FadeTimer;
 };

--- a/Source/LabelManager/Public/UI/Widget_MarketHeatmap.h
+++ b/Source/LabelManager/Public/UI/Widget_MarketHeatmap.h
@@ -6,6 +6,7 @@
 #include "Widget_MarketHeatmap.generated.h"
 
 class UListView;
+struct FTimerHandle;
 
 UCLASS()
 class UMarketRegionObject : public UObject
@@ -30,4 +31,6 @@ protected:
     UListView* HeatList;
 
     void PlayFadeIn();
+
+    FTimerHandle FadeTimer;
 };

--- a/Source/LabelManager/Public/UI/Widget_MarketRegionEntry.h
+++ b/Source/LabelManager/Public/UI/Widget_MarketRegionEntry.h
@@ -8,6 +8,7 @@
 
 class UTextBlock;
 class UProgressBar;
+struct FTimerHandle;
 
 UCLASS()
 class LABELMANAGER_API UWidget_MarketRegionEntry : public UUserWidget, public IUserObjectListEntry
@@ -24,4 +25,6 @@ protected:
     UProgressBar* IntensityBar;
 
     void PlayFadeIn();
+
+    FTimerHandle FadeTimer;
 };

--- a/Source/LabelManager/Public/UI/Widget_NewsFeed.h
+++ b/Source/LabelManager/Public/UI/Widget_NewsFeed.h
@@ -6,6 +6,7 @@
 #include "Widget_NewsFeed.generated.h"
 
 class UListView;
+struct FTimerHandle;
 
 UCLASS()
 class UNewsItemObject : public UObject
@@ -30,4 +31,6 @@ protected:
     UListView* NewsList;
 
     void PlayFadeIn();
+
+    FTimerHandle FadeTimer;
 };

--- a/Source/LabelManager/Public/UI/Widget_NewsItemEntry.h
+++ b/Source/LabelManager/Public/UI/Widget_NewsItemEntry.h
@@ -7,6 +7,7 @@
 #include "Widget_NewsItemEntry.generated.h"
 
 class UTextBlock;
+struct FTimerHandle;
 
 UCLASS()
 class LABELMANAGER_API UWidget_NewsItemEntry : public UUserWidget, public IUserObjectListEntry
@@ -23,4 +24,6 @@ protected:
     UTextBlock* DateText;
 
     void PlayFadeIn();
+
+    FTimerHandle FadeTimer;
 };

--- a/Source/LabelManager/Public/UI/Widget_ReleaseCalendar.h
+++ b/Source/LabelManager/Public/UI/Widget_ReleaseCalendar.h
@@ -9,6 +9,7 @@ class UTextBlock;
 class UButton;
 class UUniformGridPanel;
 class UListView;
+struct FTimerHandle;
 
 UCLASS()
 class UReleaseItemObject : public UObject
@@ -48,4 +49,6 @@ protected:
     UListView* UpcomingList;
 
     void PlayFadeIn();
+
+    FTimerHandle FadeTimer;
 };

--- a/Source/LabelManager/Public/UI/Widget_ReleaseItemEntry.h
+++ b/Source/LabelManager/Public/UI/Widget_ReleaseItemEntry.h
@@ -7,6 +7,7 @@
 #include "Widget_ReleaseItemEntry.generated.h"
 
 class UTextBlock;
+struct FTimerHandle;
 
 UCLASS()
 class LABELMANAGER_API UWidget_ReleaseItemEntry : public UUserWidget, public IUserObjectListEntry
@@ -26,4 +27,6 @@ protected:
     UTextBlock* DateText;
 
     void PlayFadeIn();
+
+    FTimerHandle FadeTimer;
 };

--- a/Source/LabelManager/Public/UI/Widget_SuggestedActions.h
+++ b/Source/LabelManager/Public/UI/Widget_SuggestedActions.h
@@ -6,6 +6,7 @@
 #include "Widget_SuggestedActions.generated.h"
 
 class UListView;
+struct FTimerHandle;
 
 UCLASS()
 class USuggestedActionObject : public UObject
@@ -30,4 +31,6 @@ protected:
     UListView* ActionsList;
 
     void PlayFadeIn();
+
+    FTimerHandle FadeTimer;
 };

--- a/Source/MusicLabel/Subsystems/LabelSimSubsystem.h
+++ b/Source/MusicLabel/Subsystems/LabelSimSubsystem.h
@@ -5,7 +5,18 @@
 #include "LabelSimSubsystem.generated.h"
 
 class UArtistAsset;
-struct FRelease;
+
+USTRUCT()
+struct FRelease
+{
+    GENERATED_BODY()
+
+    UPROPERTY()
+    FString Title;
+
+    UPROPERTY()
+    FDateTime ReleaseDate;
+};
 
 /** Subsystem managing label simulation timeline and events. */
 UCLASS()


### PR DESCRIPTION
## Summary
- replace unsupported `AddDays` calls with `FTimespan` arithmetic
- define a minimal `FRelease` struct for the simulation subsystem
- store timer handles as widget members and initialize list view entry classes directly
- rename `FLabelUIStyle` helper to avoid virtual method warnings

## Testing
- `clang++ -fsyntax-only Source/LabelManager/Private/UI/DashboardViewModel.cpp` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 errors; compiler could not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68addd45dbf8832e83a1a59924b7786c