### PR TITLE
Implement timed event generation subsystem

### DIFF
--- a/Source/MusicLabel/MusicLabelTypes.h
+++ b/Source/MusicLabel/MusicLabelTypes.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "Engine/DataTable.h"
 #include "MusicLabelTypes.generated.h"
 
 /** Represents a financial transaction in the game's economy. */
@@ -33,19 +34,36 @@ struct FTour
     TArray<FString> Stops;
 };
 
-/** Basic definition of a game event. */
+UENUM(BlueprintType)
+enum class EEventCategory : uint8
+{
+    NewArtistGigging      UMETA(DisplayName="New Artist Gigging (to scout)"),
+    ArtistSignedRecordDeal UMETA(DisplayName="Artist Signed a record Deal"),
+    ArtistBookedForTour   UMETA(DisplayName="Artist Booked for a tour"),
+    NewGenreEmerged       UMETA(DisplayName="New Genre has emerged")
+};
+
+/** Definition of an event entry for data tables. */
 USTRUCT(BlueprintType)
-struct FGameEvent
+struct FGameEvent : public FTableRowBase
 {
     GENERATED_BODY()
 
-    /** Text describing the event. */
+    /** Short headline for the event. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Event")
+    FString Headline;
+
+    /** When the event occurred. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Event")
+    FDateTime Date;
+
+    /** Detailed description of the event. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Event")
     FString Description;
 
-    /** Priority used to order events; higher values handled first. */
+    /** Category of the event. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Event")
-    int32 Priority = 0;
+    EEventCategory EventCategory = EEventCategory::NewArtistGigging;
 };
 
 /** Represents a single piece of music. */

--- a/Source/MusicLabel/Subsystems/EventSubsystem.cpp
+++ b/Source/MusicLabel/Subsystems/EventSubsystem.cpp
@@ -1,14 +1,64 @@
 #include "EventSubsystem.h"
+#include "Engine/World.h"
+#include "TimerManager.h"
 
 void UEventSubsystem::TriggerEvent(const FGameEvent& Event)
 {
+    UE_LOG(LogTemp, Log, TEXT("Event Triggered: %s - %s"), *Event.Headline, *Event.Description);
 }
 
 void UEventSubsystem::ResolveEvent()
 {
+    if (EventQueue.Num() > 0)
+    {
+        const FGameEvent Event = EventQueue[0];
+        UE_LOG(LogTemp, Log, TEXT("Resolving Event: %s"), *Event.Headline);
+        EventQueue.RemoveAt(0);
+    }
 }
 
 void UEventSubsystem::ScheduleEvent(const FGameEvent& Event)
 {
+    EventQueue.Add(Event);
+}
+
+void UEventSubsystem::Initialize(FSubsystemCollectionBase& Collection)
+{
+    Super::Initialize(Collection);
+
+    // Setup two sample events
+    FGameEvent GenreEvent;
+    GenreEvent.Headline = TEXT("New Genre Emerges");
+    GenreEvent.Date = FDateTime::Now();
+    GenreEvent.Description = TEXT("New genre: 50ies rock and roll has emerged.");
+    GenreEvent.EventCategory = EEventCategory::NewGenreEmerged;
+
+    FGameEvent GigEvent;
+    GigEvent.Headline = TEXT("Unsigned Artist Playing Gig");
+    GigEvent.Date = FDateTime::Now();
+    GigEvent.Description = TEXT("An new unsigned artist will play at a local bar in Detroit.");
+    GigEvent.EventCategory = EEventCategory::NewArtistGigging;
+
+    PendingEvents.Add(GenreEvent);
+    PendingEvents.Add(GigEvent);
+
+    // Start timer to trigger events every 5 seconds
+    if (UWorld* World = GetWorld())
+    {
+        World->GetTimerManager().SetTimer(EventTimer, this, &UEventSubsystem::GenerateNextEvent, 5.0f, true);
+    }
+}
+
+void UEventSubsystem::GenerateNextEvent()
+{
+    if (PendingEvents.Num() > 0)
+    {
+        TriggerEvent(PendingEvents[0]);
+        PendingEvents.RemoveAt(0);
+    }
+    else if (UWorld* World = GetWorld())
+    {
+        World->GetTimerManager().ClearTimer(EventTimer);
+    }
 }
 

--- a/Source/MusicLabel/Subsystems/EventSubsystem.h
+++ b/Source/MusicLabel/Subsystems/EventSubsystem.h
@@ -3,6 +3,7 @@
 #include "CoreMinimal.h"
 #include "Subsystems/GameInstanceSubsystem.h"
 #include "MusicLabelTypes.h"
+#include "TimerManager.h"
 #include "EventSubsystem.generated.h"
 
 /** Manages random or triggered game events. */
@@ -11,6 +12,8 @@ class MUSICLABEL_API UEventSubsystem : public UGameInstanceSubsystem
 {
     GENERATED_BODY()
 public:
+    virtual void Initialize(FSubsystemCollectionBase& Collection) override;
+
     /** Trigger an immediate event. */
     UFUNCTION(BlueprintCallable, Category="Events")
     void TriggerEvent(const FGameEvent& Event);
@@ -24,7 +27,16 @@ public:
     void ScheduleEvent(const FGameEvent& Event);
 
 private:
+    /** Generate the next pending event. */
+    void GenerateNextEvent();
+
     /** Queue of pending events. */
     TArray<FGameEvent> EventQueue;
+
+    /** Events waiting to be triggered on a timer. */
+    TArray<FGameEvent> PendingEvents;
+
+    /** Timer handle for periodic event generation. */
+    FTimerHandle EventTimer;
 };
 


### PR DESCRIPTION
## Summary
- add `EEventCategory` and data-table-ready `FGameEvent` with headline, date, description, and category
- expand `UEventSubsystem` to queue timed events and spawn two sample events every 5 seconds

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b88157a3f4832ea983d5ca49f46c3e