### PR TITLE
Refactor news item to derive from game event

### DIFF
--- a/Source/LabelManager/LabelManager.Build.cs
+++ b/Source/LabelManager/LabelManager.Build.cs
@@ -6,7 +6,7 @@ public class LabelManager : ModuleRules
     {
         PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
 
-        PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "UMG", "Slate", "SlateCore" });
+        PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "UMG", "Slate", "SlateCore", "MusicLabel" });
         PrivateDependencyModuleNames.AddRange(new string[] { });
     }
 }

--- a/Source/LabelManager/Private/UI/DashboardViewModel.cpp
+++ b/Source/LabelManager/Private/UI/DashboardViewModel.cpp
@@ -13,8 +13,15 @@ void UDashboardViewModel::RefreshAll()
     Kpi.ActiveCampaigns = 3;
 
     News.Reset();
-    News.Add({FText::FromString("Artist A tops charts"), FDateTime::UtcNow()});
-    News.Add({FText::FromString("Label signs new talent"), FDateTime::UtcNow() - FTimespan::FromDays(1)});
+    FNewsItem FirstNews;
+    FirstNews.Headline = TEXT("Artist A tops charts");
+    FirstNews.Date = FDateTime::UtcNow();
+    News.Add(FirstNews);
+
+    FNewsItem SecondNews;
+    SecondNews.Headline = TEXT("Label signs new talent");
+    SecondNews.Date = FDateTime::UtcNow() - FTimespan::FromDays(1);
+    News.Add(SecondNews);
 
     Releases.Reset();
     Releases.Add({FText::FromString("Album X"), FText::FromString("LP"), FDateTime::UtcNow() + FTimespan::FromDays(5)});

--- a/Source/LabelManager/Private/UI/Widget_NewsItemEntry.cpp
+++ b/Source/LabelManager/Private/UI/Widget_NewsItemEntry.cpp
@@ -7,8 +7,9 @@ void UWidget_NewsItemEntry::NativeOnListItemObjectSet(UObject* ListItem)
     UNewsItemObject* Obj = Cast<UNewsItemObject>(ListItem);
     if (Obj && HeadlineText)
     {
-        HeadlineText->SetText(Obj->Item.Headline);
-        HeadlineText->SetToolTipText(Obj->Item.Headline);
+        const FText Headline = FText::FromString(Obj->Item.Headline);
+        HeadlineText->SetText(Headline);
+        HeadlineText->SetToolTipText(Headline);
     }
     if (Obj && DateText)
     {

--- a/Source/LabelManager/Public/UI/DashboardViewModel.h
+++ b/Source/LabelManager/Public/UI/DashboardViewModel.h
@@ -2,6 +2,7 @@
 
 #include "CoreMinimal.h"
 #include "UObject/NoExportTypes.h"
+#include "MusicLabel/MusicLabelTypes.h"
 #include "DashboardViewModel.generated.h"
 
 USTRUCT(BlueprintType)
@@ -23,15 +24,9 @@ struct FKpiMetrics
 };
 
 USTRUCT(BlueprintType)
-struct FNewsItem
+struct FNewsItem : public FGameEvent
 {
     GENERATED_BODY()
-
-    UPROPERTY(EditAnywhere, BlueprintReadWrite)
-    FText Headline;
-
-    UPROPERTY(EditAnywhere, BlueprintReadWrite)
-    FDateTime Date;
 };
 
 USTRUCT(BlueprintType)


### PR DESCRIPTION
## Summary
- reuse `FGameEvent` in `FNewsItem` to avoid duplicate properties
- update dashboard view model and news widgets to use new base
- expose MusicLabel module to LabelManager build

## Testing
- `make test` *(fails: No rule to make target 'test')*


------
https://chatgpt.com/codex/tasks/task_e_68c107e51994832ea7bf19ffca723fc2