### PR TITLE
Add news feed item management to layout

### DIFF
--- a/Source/LabelManager/Private/UI/Layout.cpp
+++ b/Source/LabelManager/Private/UI/Layout.cpp
@@ -1,11 +1,35 @@
 #include "UI/Layout.h"
 #include "Blueprint/WidgetTree.h"
 #include "Components/CanvasPanel.h"
+#include "UI/Widget_NewsFeed.h"
 
 TSharedRef<SWidget> ULayout::RebuildWidget()
 {
     RootCanvas = WidgetTree->ConstructWidget<UCanvasPanel>(UCanvasPanel::StaticClass(), TEXT("RootCanvas"));
     WidgetTree->RootWidget = RootCanvas;
+
+    NewsFeedWidget = WidgetTree->ConstructWidget<UWidget_NewsFeed>(UWidget_NewsFeed::StaticClass(), TEXT("NewsFeed"));
+    if (NewsFeedWidget)
+    {
+        RootCanvas->AddChild(NewsFeedWidget);
+    }
+
     return RootCanvas->TakeWidget();
+}
+
+void ULayout::AddNewsItemToTop(const FNewsItem& Item)
+{
+    if (NewsFeedWidget)
+    {
+        NewsFeedWidget->AddNewsItemToTop(Item);
+    }
+}
+
+void ULayout::RemoveLastNewsItem()
+{
+    if (NewsFeedWidget)
+    {
+        NewsFeedWidget->RemoveLastNewsItem();
+    }
 }
 

--- a/Source/LabelManager/Private/UI/Widget_NewsFeed.cpp
+++ b/Source/LabelManager/Private/UI/Widget_NewsFeed.cpp
@@ -28,6 +28,28 @@ void UWidget_NewsFeed::SetNews(const TArray<FNewsItem> &InNews) {
   NewsList->SetListItems(Items);
 }
 
+void UWidget_NewsFeed::AddNewsItemToTop(const FNewsItem &Item) {
+  if (!NewsList)
+    return;
+  TArray<UObject *> Items = NewsList->GetListItems();
+  UNewsItemObject *Obj = NewObject<UNewsItemObject>(this);
+  Obj->Item = Item;
+  Items.Insert(Obj, 0);
+  NewsList->ClearListItems();
+  NewsList->SetListItems(Items);
+}
+
+void UWidget_NewsFeed::RemoveLastNewsItem() {
+  if (!NewsList)
+    return;
+  TArray<UObject *> Items = NewsList->GetListItems();
+  if (Items.Num() > 0) {
+    Items.Pop();
+    NewsList->ClearListItems();
+    NewsList->SetListItems(Items);
+  }
+}
+
 void UWidget_NewsFeed::PlayFadeIn() {
   SetRenderOpacity(0.f);
   float Opacity = 0.f;

--- a/Source/LabelManager/Public/UI/Layout.h
+++ b/Source/LabelManager/Public/UI/Layout.h
@@ -5,6 +5,8 @@
 #include "Layout.generated.h"
 
 class UCanvasPanel;
+class UWidget_NewsFeed;
+struct FNewsItem;
 
 UCLASS()
 class LABELMANAGER_API ULayout : public UUserWidget
@@ -16,5 +18,15 @@ protected:
 
     UPROPERTY()
     UCanvasPanel* RootCanvas;
+
+    UPROPERTY()
+    UWidget_NewsFeed* NewsFeedWidget;
+
+public:
+    UFUNCTION(BlueprintCallable)
+    void AddNewsItemToTop(const FNewsItem& Item);
+
+    UFUNCTION(BlueprintCallable)
+    void RemoveLastNewsItem();
 };
 

--- a/Source/LabelManager/Public/UI/Widget_NewsFeed.h
+++ b/Source/LabelManager/Public/UI/Widget_NewsFeed.h
@@ -28,6 +28,12 @@ public:
     UFUNCTION(BlueprintCallable)
     void SetNews(const TArray<FNewsItem>& InNews);
 
+    UFUNCTION(BlueprintCallable)
+    void AddNewsItemToTop(const FNewsItem& Item);
+
+    UFUNCTION(BlueprintCallable)
+    void RemoveLastNewsItem();
+
 protected:
     UPROPERTY(meta=(BindWidget))
     UListView* NewsList;


### PR DESCRIPTION
## Summary
- Embed `UWidget_NewsFeed` in `ULayout` and expose methods to add/remove news items
- Implement news item insertion and removal logic in `UWidget_NewsFeed`

## Testing
- `dotnet build MusicLabel.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c10a0cb4b4832e82f46ff1fc774e41