### PR TITLE
Recreate layout widget when stale pointers are detected

### DIFF
--- a/Source/LabelManager/Private/LabelManagerGameInstance.cpp
+++ b/Source/LabelManager/Private/LabelManagerGameInstance.cpp
@@ -13,6 +13,11 @@ void ULabelManagerGameInstance::Init()
 {
     Super::Init();
 
+    if (!IsValid(LayoutGUI))
+    {
+        LayoutGUI = nullptr;
+    }
+
     if (!LayoutGUI && LayoutGUIClass)
     {
         LayoutGUI = CreateWidget<ULayout>(this, LayoutGUIClass);
@@ -25,6 +30,11 @@ void ULabelManagerGameInstance::Init()
 
 ULayout* ULabelManagerGameInstance::EnsureLayoutForPlayer(APlayerController* OwningPlayer)
 {
+    if (!IsValid(LayoutGUI))
+    {
+        LayoutGUI = nullptr;
+    }
+
     if (!LayoutGUI && LayoutGUIClass)
     {
         LayoutGUI = CreateWidget<ULayout>(this, LayoutGUIClass);


### PR DESCRIPTION
## Summary
- reset the cached layout widget pointer if it has become invalid
- recreate and re-add the layout widget before returning it to callers

## Testing
- not run (not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910a71ff3bc832e84c7590353ea38a5)